### PR TITLE
Add streaming UI, conversation persistence, safety hardening, and 161 tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- Brief description of what this PR does and why -->
+
+## Changes
+
+-
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Enhancement to existing feature
+- [ ] Documentation update
+- [ ] Refactoring (no functional change)
+- [ ] CI / build change
+
+## Testing
+
+- [ ] Added/updated unit tests
+- [ ] All existing tests pass (`pytest edgetutor/tests/ -v`)
+- [ ] Lint passes (`ruff check edgetutor/`)
+- [ ] Format passes (`ruff format --check edgetutor/`)
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have added docstrings to new public functions/classes
+- [ ] I have updated documentation if needed
+- [ ] My changes don't break offline functionality
+- [ ] Safety filters are maintained (if touching safety-related code)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, agent/mvp]
+    branches: [main, agent/mvp, agent/mentor-evolution]
   pull_request:
     branches: [main]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to EdgeTutor AI
+
+Thanks for your interest in contributing to EdgeTutor AI! This project aims to bring offline AI tutoring to every student with an NVIDIA Jetson device.
+
+## Development Setup
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/thatcooperguy/Nvidia_Jetson_AI_Tutor.git
+cd Nvidia_Jetson_AI_Tutor
+```
+
+### 2. Create a virtual environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+### 3. Install dependencies
+
+For **development / CI** (lightweight, no GPU dependencies):
+
+```bash
+pip install -e ".[dev]"
+```
+
+For **full local testing** with all AI modules:
+
+```bash
+pip install -e ".[all]"
+```
+
+> On Jetson devices, use `./scripts/setup_jetson.sh` which handles CUDA-accelerated builds automatically.
+
+### 4. Install system dependencies
+
+Tesseract OCR is needed for tests:
+
+```bash
+# Ubuntu / Debian
+sudo apt-get install tesseract-ocr tesseract-ocr-eng
+```
+
+## Running Tests
+
+```bash
+pytest edgetutor/tests/ -v
+```
+
+Tests are designed to run **without** GPU hardware, LLM models, or TTS voices. All hardware-dependent features are auto-disabled in the test fixtures.
+
+## Linting & Formatting
+
+We use [ruff](https://docs.astral.sh/ruff/) for linting and formatting:
+
+```bash
+# Check for lint issues
+ruff check edgetutor/
+
+# Auto-fix lint issues
+ruff check edgetutor/ --fix
+
+# Check formatting
+ruff format --check edgetutor/
+
+# Auto-format
+ruff format edgetutor/
+```
+
+CI enforces both `ruff check` and `ruff format --check` on every push.
+
+## Pull Request Guidelines
+
+1. **Fork** the repository and create a feature branch from `main`
+2. **Write tests** for new functionality
+3. **Run the full check** before submitting:
+   ```bash
+   ruff check edgetutor/ && ruff format --check edgetutor/ && pytest edgetutor/tests/ -v
+   ```
+4. **Keep PRs focused** — one feature or fix per PR
+5. **Write clear commit messages** describing _why_, not just _what_
+6. **Update documentation** if your change affects user-facing behavior
+
+## Code Style
+
+- Python 3.10+ with `from __future__ import annotations`
+- Type hints on all public functions
+- Use `X | None` instead of `Optional[X]`
+- Use `collections.abc.Generator` instead of `typing.Generator`
+- Docstrings on all public classes and methods
+- Imports sorted by ruff (isort-compatible)
+
+## Architecture Notes
+
+- **Modules are lazy-loaded** — heavy imports (llama-cpp, whisper, faiss) happen inside methods, not at module level
+- **Graceful degradation** — if a module fails to load, others keep working
+- **Singleton pattern** — `get_llm()`, `get_stt()`, `get_tts()`, `get_rag()` return cached instances
+- **Settings via pydantic-settings** — all config flows through `edgetutor/core/settings.py`
+- **Kid-safe by default** — safety filters are always on unless explicitly disabled
+
+## Dependency Tiers
+
+| Extra | What's included | When to use |
+|-------|----------------|-------------|
+| _(base)_ | pydantic, numpy, Pillow, pytesseract | Always installed |
+| `[dev]` | pytest, ruff, black | CI and development |
+| `[ai]` | gradio, llama-cpp, whisper, piper, faiss, sentence-transformers | On-device with full AI stack |
+| `[all]` | Everything above | Full local development |
+
+## Reporting Issues
+
+- Use [GitHub Issues](https://github.com/thatcooperguy/Nvidia_Jetson_AI_Tutor/issues)
+- Include your Jetson model, JetPack version, and Python version
+- For crashes, include the full traceback from `logs/edgetutor.log`
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for reporting vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -221,16 +221,37 @@ edgetutor-ai/
 
 ## 🧪 Development
 
+### Install for Development
+
+```bash
+# Lightweight (CI / testing only — no heavy AI deps)
+pip install -e ".[dev]"
+
+# Full stack (includes Gradio, LLM, STT, TTS, RAG)
+pip install -e ".[all]"
+```
+
+> **On Jetson**: Use `./scripts/setup_jetson.sh` — it installs everything including
+> CUDA-accelerated llama.cpp automatically.
+
+### Dependency Extras
+
+| Extra | What's included | Use case |
+|-------|----------------|----------|
+| _(base)_ | pydantic, numpy, Pillow, pytesseract | Always installed |
+| `[dev]` | pytest, ruff, black | CI and linting |
+| `[ai]` | gradio, llama-cpp, whisper, piper, faiss, sentence-transformers | On-device inference |
+| `[all]` | `[ai]` + `[dev]` combined | Full local development |
+
 ### Run Tests
 ```bash
-source .venv/bin/activate
 pytest edgetutor/tests/ -v
 ```
 
-### Lint
+### Lint & Format
 ```bash
-pip install ruff
 ruff check edgetutor/
+ruff format --check edgetutor/
 ```
 
 ### Run in Debug Mode
@@ -255,12 +276,11 @@ for planned features:
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please:
+Contributions are welcome! See **[CONTRIBUTING.md](CONTRIBUTING.md)** for:
 
-1. Fork the repository
-2. Create a feature branch
-3. Write tests for new functionality
-4. Submit a pull request
+- Development setup and dependency tiers
+- Testing, linting, and formatting instructions
+- Pull request guidelines and code style
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,28 @@
 # 🎓 EdgeTutor AI
 
-**An offline AI tutor for NVIDIA Jetson — voice, vision, and chat for students.**
+**Offline-first AI Tutor + AI Mentor for NVIDIA Tegra / Jetson platforms.**
 
 [![CI](https://github.com/thatcooperguy/Nvidia_Jetson_AI_Tutor/actions/workflows/ci.yml/badge.svg)](https://github.com/thatcooperguy/Nvidia_Jetson_AI_Tutor/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-green.svg)](https://python.org)
 
-EdgeTutor AI is a **fully offline**, **kid-safe** AI tutoring system that runs
-on an NVIDIA Jetson device. Students can ask questions by typing, speaking, or
-holding up a worksheet — and the tutor responds with age-appropriate,
-Socratic-style guidance.
+EdgeTutor AI is a **fully offline**, **kid-safe**, **hardware-aware** AI
+platform that runs on NVIDIA Jetson devices (and compatible Tegra-based
+systems). It's three things in one:
 
-**No cloud. No telemetry. No internet required at runtime.**
+1. **📚 A Learning Tutor** — Students ask questions by typing, speaking, or
+   holding up a worksheet. The tutor responds with age-appropriate,
+   Socratic-style guidance.
+2. **🧠 An AI Mentor** — Learn how GPUs, CUDA, LLMs, quantization, and edge
+   AI actually work — using the real hardware sitting on your desk.
+3. **🔬 A Local AI Lab** — An introduction to building and running AI systems
+   on real hardware, with no cloud dependency.
+
+**Setup online once. Inference stays local. No telemetry. No cloud calls at runtime.**
+
+> **⚠️ Disclaimer:** This is an independent open-source project and is **not
+> affiliated with or endorsed by NVIDIA**. NVIDIA, Jetson, Tegra, JetPack,
+> and related marks are trademarks of NVIDIA Corporation.
 
 ---
 
@@ -20,6 +31,7 @@ Socratic-style guidance.
 | Feature | Description |
 |---------|-------------|
 | 💬 **Chat Tutor** | Ask any school subject question via text |
+| 🧠 **AI Mentor** | Learn how GPUs, CUDA, LLMs, and AI work — on real hardware |
 | 🎤 **Voice Input** | Push-to-talk speech recognition (faster-whisper) |
 | 🔊 **Voice Output** | Tutor speaks responses aloud (Piper TTS) |
 | 📷 **Worksheet Scanner** | Hold up a page → OCR → explain step-by-step |
@@ -30,8 +42,9 @@ Socratic-style guidance.
 | 🔓 **Parent Mode** | Direct answers + advanced settings |
 | 📖 **Content Packs** | RAG with your own curriculum (PDF/TXT/MD) |
 | 🛡️ **Kid-Safe** | Content filtering — refuses unsafe requests |
-| 🖥️ **Web UI** | Gradio interface accessible from any device on LAN |
-| ⚡ **Jetson Optimized** | CUDA/GPU acceleration, adaptive model selection |
+| 🖥️ **Dark Theme UI** | Clean, inspiring Gradio interface on LAN |
+| ⚡ **Hardware-Aware** | Auto-detects Jetson model, scales models to fit RAM |
+| 🔄 **Auto-Scaling** | Tiered fallback: picks the best model for your device |
 
 ---
 
@@ -47,11 +60,21 @@ Socratic-style guidance.
 - USB microphone (for voice input)
 - Speaker (for TTS output)
 
-### Also Works On
-- Jetson Orin NX 8/16GB
-- Jetson AGX Orin 32/64GB
-- Jetson Xavier NX (limited)
-- Any Linux system with NVIDIA GPU (for development)
+### Supported Tegra / Jetson Platforms
+
+| Platform | RAM | Status | Notes |
+|----------|-----|--------|-------|
+| **Orin Nano 8GB** | 8 GB | ⭐ Primary target | Best value |
+| **Orin Nano 4GB** | 4 GB | ✅ Supported | Smaller models auto-selected |
+| **Orin NX 8/16GB** | 8-16 GB | ✅ Supported | Great performance |
+| **AGX Orin 32/64GB** | 32-64 GB | ✅ Supported | Premium, can run larger models |
+| **Xavier NX** | 8 GB | ⚠️ Limited | Older GPU arch, use small models |
+| **Jetson Nano (orig)** | 4 GB | ⚠️ Minimal | Very constrained |
+| **Tegra / Spark (Linux)** | Varies | 🔬 Experimental | Where local inference is available |
+| **Any Linux + NVIDIA GPU** | 4+ GB | ✅ Dev/Testing | For development on desktop |
+
+The system **auto-detects your hardware** and selects appropriate models.
+JetPack 5.x and 6.x (Ubuntu 20.04 / 22.04) are both supported.
 
 > **📋 Full hardware guide with Amazon links**: [docs/HARDWARE_SETUP.md](docs/HARDWARE_SETUP.md)
 

--- a/edgetutor/__main__.py
+++ b/edgetutor/__main__.py
@@ -7,6 +7,7 @@ Usage:
 
 import sys
 
+from edgetutor import __version__
 from edgetutor.core.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -14,7 +15,7 @@ logger = get_logger(__name__)
 
 def main():
     """Launch EdgeTutor AI."""
-    logger.info("Starting EdgeTutor AI v0.1.0")
+    logger.info("Starting EdgeTutor AI v%s", __version__)
     logger.info("=" * 60)
     logger.info("  EdgeTutor AI — Offline AI Tutor for NVIDIA Jetson")
     logger.info("  Access the UI at: http://localhost:7860")

--- a/edgetutor/app/orchestrator.py
+++ b/edgetutor/app/orchestrator.py
@@ -150,9 +150,7 @@ class TutorOrchestrator:
         user_text = request.user_text
         if request.audio_array is not None and self._stt and self._stt.is_ready:
             t0 = time.time()
-            result = self._stt.transcribe_numpy(
-                request.audio_array, request.audio_sample_rate
-            )
+            result = self._stt.transcribe_numpy(request.audio_array, request.audio_sample_rate)
             response.latency["stt"] = time.time() - t0
             if result.get("text"):
                 user_text = result["text"]
@@ -259,7 +257,9 @@ class TutorOrchestrator:
         )
 
         response.latency["total"] = time.time() - total_t0
-        logger.info("Orchestrator total: %.1fs — latency=%s", response.latency["total"], response.latency)
+        logger.info(
+            "Orchestrator total: %.1fs — latency=%s", response.latency["total"], response.latency
+        )
 
         return response
 
@@ -359,9 +359,7 @@ class TutorOrchestrator:
         if "quiz_mode" in overrides:
             cfg.quiz_mode = bool(overrides["quiz_mode"])
 
-    def _generate_suggestions(
-        self, user_text: str, ocr_text: str, subject: str
-    ) -> list[str]:
+    def _generate_suggestions(self, user_text: str, ocr_text: str, subject: str) -> list[str]:
         """Generate 'next steps' suggestions based on context."""
         suggestions = []
 

--- a/edgetutor/app/orchestrator.py
+++ b/edgetutor/app/orchestrator.py
@@ -8,8 +8,8 @@ routes through the appropriate modules, and produces a tutor response.
 from __future__ import annotations
 
 import time
+from collections.abc import Generator
 from dataclasses import dataclass, field
-from typing import Generator, Optional
 
 from edgetutor.core.logging_config import get_logger
 from edgetutor.core.settings import get_settings
@@ -22,11 +22,11 @@ class TutorRequest:
     """Input to the orchestrator."""
 
     user_text: str = ""
-    audio_path: Optional[str] = None
-    audio_array: Optional[object] = None  # numpy array from Gradio
+    audio_path: str | None = None
+    audio_array: object | None = None  # numpy array from Gradio
     audio_sample_rate: int = 16000
-    image: Optional[object] = None  # PIL Image or numpy array
-    settings_override: Optional[dict] = None
+    image: object | None = None  # PIL Image or numpy array
+    settings_override: dict | None = None
 
 
 @dataclass
@@ -34,7 +34,7 @@ class TutorResponse:
     """Output from the orchestrator."""
 
     text: str = ""
-    audio: Optional[tuple] = None  # (sample_rate, numpy_array) for Gradio
+    audio: tuple | None = None  # (sample_rate, numpy_array) for Gradio
     ocr_text: str = ""
     has_math: bool = False
     math_expressions: list[str] = field(default_factory=list)
@@ -133,7 +133,7 @@ class TutorOrchestrator:
     def process(
         self,
         request: TutorRequest,
-        conversation_history: Optional[list[dict]] = None,
+        conversation_history: list[dict] | None = None,
     ) -> TutorResponse:
         """
         Process a tutor request end-to-end (non-streaming).
@@ -266,7 +266,7 @@ class TutorOrchestrator:
     def process_stream(
         self,
         request: TutorRequest,
-        conversation_history: Optional[list[dict]] = None,
+        conversation_history: list[dict] | None = None,
     ) -> Generator[str, None, None]:
         """
         Process a tutor request with streaming LLM output.

--- a/edgetutor/app/orchestrator.py
+++ b/edgetutor/app/orchestrator.py
@@ -57,6 +57,11 @@ class TutorOrchestrator:
         self._ocr = None
         self._rag = None
 
+    @property
+    def llm(self):
+        """Public access to the LLM backend (for mentor mode, etc.)."""
+        return self._llm
+
     def load_modules(self) -> dict:
         """
         Load all available modules. Returns status dict.
@@ -145,6 +150,17 @@ class TutorOrchestrator:
         # Apply settings overrides if any
         if request.settings_override:
             self._apply_settings(request.settings_override)
+
+        # ─── Early safety check on raw text input ─────────────────────────
+        if cfg.safety_enabled and request.user_text:
+            from edgetutor.core.safety import check_input_safety, get_redirect_message
+
+            is_safe, category = check_input_safety(request.user_text)
+            if not is_safe:
+                logger.info("Orchestrator blocked input: category=%s", category)
+                response.text = get_redirect_message()
+                response.latency["total"] = time.time() - total_t0
+                return response
 
         # ─── Step 1: Speech-to-text (if audio provided) ──────────────────
         user_text = request.user_text
@@ -279,6 +295,15 @@ class TutorOrchestrator:
         if request.settings_override:
             self._apply_settings(request.settings_override)
 
+        # ─── Early safety check ──────────────────────────────────────────
+        if cfg.safety_enabled and request.user_text:
+            from edgetutor.core.safety import check_input_safety, get_redirect_message
+
+            is_safe, _category = check_input_safety(request.user_text)
+            if not is_safe:
+                yield get_redirect_message()
+                return
+
         # STT
         user_text = request.user_text
         if request.audio_array is not None and self._stt and self._stt.is_ready:
@@ -334,11 +359,24 @@ class TutorOrchestrator:
             yield "Hi! I'm EdgeTutor. Ask me anything or scan a worksheet!"
             return
 
-        # Stream LLM
-        yield from self._llm.generate_stream(
+        # Stream LLM — accumulate and check output safety afterward
+        accumulated = ""
+        for token in self._llm.generate_stream(
             user_message=final_message,
             conversation_history=conversation_history,
-        )
+        ):
+            accumulated += token
+            yield token
+
+        # Post-stream output safety check
+        if cfg.safety_enabled and accumulated:
+            from edgetutor.core.safety import check_output_safety
+
+            scrubbed = check_output_safety(accumulated)
+            if scrubbed != accumulated:
+                # Yield a replacement marker — the UI should use the final
+                # accumulated text, so we signal that a replacement happened.
+                yield "\n\n[Response replaced by safety filter]"
 
     def _apply_settings(self, overrides: dict) -> None:
         """Apply runtime setting overrides."""

--- a/edgetutor/app/orchestrator.py
+++ b/edgetutor/app/orchestrator.py
@@ -10,9 +10,15 @@ from __future__ import annotations
 import time
 from collections.abc import Generator
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from edgetutor.core.logging_config import get_logger
 from edgetutor.core.settings import get_settings
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+    from PIL import Image
 
 logger = get_logger(__name__)
 
@@ -23,9 +29,9 @@ class TutorRequest:
 
     user_text: str = ""
     audio_path: str | None = None
-    audio_array: object | None = None  # numpy array from Gradio
+    audio_array: NDArray[np.float32] | None = None
     audio_sample_rate: int = 16000
-    image: object | None = None  # PIL Image or numpy array
+    image: Image.Image | NDArray | None = None
     settings_override: dict | None = None
 
 

--- a/edgetutor/app/orchestrator.py
+++ b/edgetutor/app/orchestrator.py
@@ -196,8 +196,8 @@ class TutorOrchestrator:
         # ─── Step 4: Build the prompt and call LLM ───────────────────────
         if self._llm and self._llm.is_loaded:
             from edgetutor.core.prompts import (
-                build_rag_context,
                 build_quiz_prompt,
+                build_rag_context,
                 build_vision_prompt,
             )
 
@@ -312,7 +312,7 @@ class TutorOrchestrator:
             yield "[EdgeTutor] Language model not loaded. Check models/ folder."
             return
 
-        from edgetutor.core.prompts import build_rag_context, build_quiz_prompt, build_vision_prompt
+        from edgetutor.core.prompts import build_quiz_prompt, build_rag_context, build_vision_prompt
 
         if ocr_text:
             final_message = build_vision_prompt(ocr_text=ocr_text, is_math=has_math)
@@ -342,19 +342,18 @@ class TutorOrchestrator:
 
     def _apply_settings(self, overrides: dict) -> None:
         """Apply runtime setting overrides."""
-        cfg = get_settings()
+        import contextlib
+
         from edgetutor.core.settings import AgeMode, SubjectMode
 
+        cfg = get_settings()
+
         if "age_mode" in overrides:
-            try:
+            with contextlib.suppress(ValueError):
                 cfg.age_mode = AgeMode(str(overrides["age_mode"]))
-            except ValueError:
-                pass
         if "subject_mode" in overrides:
-            try:
+            with contextlib.suppress(ValueError):
                 cfg.subject_mode = SubjectMode(overrides["subject_mode"])
-            except ValueError:
-                pass
         if "parent_mode" in overrides:
             cfg.parent_mode = bool(overrides["parent_mode"])
         if "quiz_mode" in overrides:

--- a/edgetutor/app/ui.py
+++ b/edgetutor/app/ui.py
@@ -7,9 +7,6 @@ Dark theme. Supports: AI Tutor, AI Mentor, camera/voice, settings.
 
 from __future__ import annotations
 
-import time
-from typing import Optional
-
 import gradio as gr
 
 from edgetutor.core.logging_config import get_logger
@@ -80,8 +77,8 @@ def _get_system_info_html() -> str:
 # ── Chat handler ──────────────────────────────────────────────────────────────
 def _chat_respond(
     message: str,
-    audio: Optional[tuple] = None,
-    image: Optional[object] = None,
+    audio: tuple | None = None,
+    image: object | None = None,
     history: list = None,
     age_mode: str = "10",
     subject_mode: str = "general",

--- a/edgetutor/app/ui.py
+++ b/edgetutor/app/ui.py
@@ -2,7 +2,7 @@
 EdgeTutor AI — Gradio Web UI.
 
 Local web interface served on LAN (default localhost:7860).
-Supports: chat, push-to-talk voice, camera/image capture, settings panel.
+Dark theme. Supports: AI Tutor, AI Mentor, camera/voice, settings.
 """
 
 from __future__ import annotations
@@ -17,32 +17,67 @@ from edgetutor.core.settings import get_settings
 
 logger = get_logger(__name__)
 
-# ── Global orchestrator reference (set during build) ──────────────────────────
+# ── Global state ──────────────────────────────────────────────────────────────
 _orchestrator = None
 _module_status = {}
 
 
 def _get_module_status_html() -> str:
-    """Format module status as colored HTML badges."""
+    """Format module status as colored HTML badges for dark theme."""
     badges = []
     for module, status in _module_status.items():
         if "ready" in status.lower():
-            color = "#4caf50"
+            color = "#76ff03"
             icon = "✅"
         elif "disabled" in status.lower() or "not loaded" in status.lower():
-            color = "#ff9800"
+            color = "#ffc107"
             icon = "⚠️"
         else:
-            color = "#f44336"
+            color = "#ff5252"
             icon = "❌"
         badges.append(
-            f'<span style="background:{color}22;color:{color};padding:2px 8px;'
-            f'border-radius:12px;font-size:0.85em;margin:2px">'
-            f"{icon} {module}: {status}</span>"
+            f'<span style="background:{color}15;color:{color};padding:3px 10px;'
+            f'border-radius:14px;font-size:0.8em;margin:2px;border:1px solid {color}33">'
+            f"{icon} <strong>{module}</strong>: {status}</span>"
         )
     return " ".join(badges)
 
 
+def _get_system_info_html() -> str:
+    """Generate system info panel HTML for AI Mentor mode."""
+    try:
+        from edgetutor.core.jetson import get_full_system_info
+        info = get_full_system_info()
+        return f"""
+        <div style="font-family:monospace;font-size:0.85em;line-height:1.6;
+                    background:#1a1a2e;padding:16px;border-radius:10px;border:1px solid #333">
+            <div style="color:#76ff03;font-weight:bold;margin-bottom:8px">
+                🖥️ YOUR AI LAB — System Stats
+            </div>
+            <table style="width:100%;color:#ccc">
+                <tr><td style="color:#888">Board</td><td><strong>{info['board_name']}</strong></td></tr>
+                <tr><td style="color:#888">GPU</td><td>{info['gpu_name']}</td></tr>
+                <tr><td style="color:#888">CUDA Cores</td><td>{info['cuda_cores']}</td></tr>
+                <tr><td style="color:#888">CPU Cores</td><td>{info['cpu_cores']}</td></tr>
+                <tr><td style="color:#888">RAM</td><td>{info['ram_total_gb']:.1f} GB total / {info['ram_available_gb']:.1f} GB free</td></tr>
+                <tr><td style="color:#888">GPU Memory</td><td>{info['gpu_mem_total_gb']:.1f} GB (shared)</td></tr>
+                <tr><td style="color:#888">Power Mode</td><td>{info['power_mode']}</td></tr>
+                <tr><td style="color:#888">Tegra</td><td>{'Yes ✓' if info['is_tegra'] else 'No'}</td></tr>
+                <tr><td colspan="2" style="border-top:1px solid #333;padding-top:6px"></td></tr>
+                <tr><td style="color:#888">Active LLM</td><td style="color:#76ff03">{info['recommended_model']}</td></tr>
+                <tr><td style="color:#888">GPU Layers</td><td>{info['recommended_gpu_layers']}</td></tr>
+                <tr><td style="color:#888">Context</td><td>{info['recommended_context']} tokens</td></tr>
+                <tr><td style="color:#888">STT Model</td><td>Whisper {info['recommended_stt']}</td></tr>
+                <tr><td style="color:#888">Scaling</td><td style="color:#ffc107;font-size:0.85em">{info['scaling_reason']}</td></tr>
+            </table>
+        </div>
+        """
+    except Exception as e:
+        logger.warning("Could not generate system info HTML: %s", e)
+        return '<div style="color:#888">System info unavailable.</div>'
+
+
+# ── Chat handler ──────────────────────────────────────────────────────────────
 def _chat_respond(
     message: str,
     audio: Optional[tuple] = None,
@@ -53,20 +88,16 @@ def _chat_respond(
     parent_mode: bool = False,
     quiz_mode: bool = False,
 ):
-    """
-    Main chat handler. Processes text, audio, and/or image input.
-    Returns updated chat history.
-    """
+    """Main chat handler for AI Tutor mode."""
     if history is None:
         history = []
 
     if _orchestrator is None:
-        history.append({"role": "assistant", "content": "⚠️ System not initialized. Please restart."})
+        history.append({"role": "assistant", "content": "⚠️ System not initialized."})
         return history, history, None, ""
 
     from edgetutor.app.orchestrator import TutorRequest
 
-    # Build request
     request = TutorRequest(
         user_text=message or "",
         settings_override={
@@ -77,34 +108,27 @@ def _chat_respond(
         },
     )
 
-    # Handle audio input
     if audio is not None:
         try:
-            import numpy as np
-
             sr, audio_data = audio
             request.audio_array = audio_data
             request.audio_sample_rate = sr
         except Exception as e:
             logger.error("Audio processing error: %s", e)
 
-    # Handle image input
     if image is not None:
         request.image = image
 
-    # Build conversation history for context
     conv_history = []
-    for msg in (history or [])[-10:]:  # Keep last 10 messages for context
+    for msg in (history or [])[-10:]:
         if isinstance(msg, dict):
             conv_history.append({
                 "role": msg.get("role", "user"),
                 "content": msg.get("content", ""),
             })
 
-    # Process request
     response = _orchestrator.process(request, conversation_history=conv_history)
 
-    # Determine what the user said (for display)
     display_text = message
     if not display_text and request.audio_array is not None:
         display_text = "🎤 [Voice input]"
@@ -113,10 +137,8 @@ def _chat_respond(
     if not display_text:
         display_text = "..."
 
-    # Update history
     history.append({"role": "user", "content": display_text.strip()})
 
-    # Format response with extras
     response_text = response.text
     if response.ocr_text:
         response_text = f"📝 **Extracted text:**\n> {response.ocr_text[:300]}{'...' if len(response.ocr_text) > 300 else ''}\n\n{response_text}"
@@ -124,54 +146,80 @@ def _chat_respond(
         math_preview = "\n".join(f"- `{expr}`" for expr in response.math_expressions[:5])
         response_text = f"🔢 **Math detected:**\n{math_preview}\n\n{response_text}"
 
-    # Add latency info (small footer)
-    latency_parts = []
-    for k, v in response.latency.items():
-        latency_parts.append(f"{k}: {v:.1f}s")
+    latency_parts = [f"{k}: {v:.1f}s" for k, v in response.latency.items()]
     if latency_parts:
         response_text += f"\n\n<small>⏱️ {' | '.join(latency_parts)}</small>"
 
     history.append({"role": "assistant", "content": response_text})
-
     return history, history, response.audio, ""
 
 
-def _scan_worksheet(
-    image: Optional[object],
-    history: list,
-    age_mode: str,
-    subject_mode: str,
-    parent_mode: bool,
+# ── Mentor chat handler ───────────────────────────────────────────────────────
+def _mentor_respond(
+    message: str,
+    mentor_topic: str,
+    history: list = None,
+    age_mode: str = "10",
 ):
-    """Handle 'Scan Worksheet' button click."""
+    """Chat handler for AI Mentor mode."""
+    if history is None:
+        history = []
+
+    if _orchestrator is None or not _orchestrator._llm or not _orchestrator._llm.is_loaded:
+        history.append({"role": "assistant", "content": "⚠️ LLM not loaded. Check models/ folder."})
+        return history, history, ""
+
+    from edgetutor.core.mentor import build_mentor_prompt, get_mentor_topic_prompt
+
+    # If a topic button was clicked, use that topic's prompt
+    actual_message = message
+    if mentor_topic and mentor_topic != "none" and not message.strip():
+        actual_message = get_mentor_topic_prompt(mentor_topic)
+    elif not actual_message.strip():
+        actual_message = "Tell me about this Jetson device and how AI works on it!"
+
+    system_prompt = build_mentor_prompt(age=age_mode)
+
+    conv_history = []
+    for msg in (history or [])[-10:]:
+        if isinstance(msg, dict):
+            conv_history.append({
+                "role": msg.get("role", "user"),
+                "content": msg.get("content", ""),
+            })
+
+    display_text = message if message.strip() else f"📖 [Topic: {mentor_topic}]"
+    history.append({"role": "user", "content": display_text})
+
+    response_text = _orchestrator._llm.generate(
+        user_message=actual_message,
+        system_prompt=system_prompt,
+        conversation_history=conv_history,
+    )
+
+    history.append({"role": "assistant", "content": response_text})
+    return history, history, ""
+
+
+# ── Worksheet scanner ─────────────────────────────────────────────────────────
+def _scan_worksheet(image, history, age_mode, subject_mode, parent_mode):
     if image is None:
         history = history or []
-        history.append({"role": "assistant", "content": "📷 Please capture or upload an image first, then click 'Scan Worksheet'."})
+        history.append({"role": "assistant", "content": "📷 Upload or capture an image first!"})
         return history, history, None
 
     return _chat_respond(
         message="Please explain this worksheet step by step.",
-        image=image,
-        history=history,
-        age_mode=age_mode,
-        subject_mode=subject_mode,
-        parent_mode=parent_mode,
-        quiz_mode=False,
+        image=image, history=history, age_mode=age_mode,
+        subject_mode=subject_mode, parent_mode=parent_mode,
     )[:3]
 
 
-def _explain_step_by_step(
-    history: list,
-    age_mode: str,
-    subject_mode: str,
-    parent_mode: bool,
-):
-    """Handle 'Explain Step-by-Step' button."""
+def _explain_step_by_step(history, age_mode, subject_mode, parent_mode):
     if not history:
-        history = [{"role": "assistant", "content": "There's nothing to explain yet! Ask me a question first."}]
+        history = [{"role": "assistant", "content": "Ask me a question first!"}]
         return history, history
 
-    # Get the last user message to re-explain
     last_user = ""
     for msg in reversed(history):
         if isinstance(msg, dict) and msg.get("role") == "user":
@@ -179,176 +227,265 @@ def _explain_step_by_step(
             break
 
     if not last_user:
-        history.append({"role": "assistant", "content": "Ask me a question first, and I'll explain it step by step!"})
+        history.append({"role": "assistant", "content": "Ask me a question first!"})
         return history, history
 
     result = _chat_respond(
         message=f"Please explain this step by step in detail: {last_user}",
-        history=history,
-        age_mode=age_mode,
-        subject_mode=subject_mode,
-        parent_mode=parent_mode,
+        history=history, age_mode=age_mode,
+        subject_mode=subject_mode, parent_mode=parent_mode,
     )
     return result[0], result[1]
 
 
+# ── Build the full UI ─────────────────────────────────────────────────────────
 def build_ui() -> gr.Blocks:
-    """Build and return the Gradio Blocks interface."""
+    """Build the Gradio dark-themed interface with Tutor + Mentor tabs."""
     global _orchestrator, _module_status
 
     from edgetutor.app.orchestrator import get_orchestrator
-
     _orchestrator = get_orchestrator()
     _module_status = _orchestrator.load_modules()
 
-    theme = gr.themes.Soft(
-        primary_hue="blue",
-        secondary_hue="cyan",
-        neutral_hue="slate",
+    # Dark theme
+    theme = gr.themes.Base(
+        primary_hue=gr.themes.colors.blue,
+        secondary_hue=gr.themes.colors.cyan,
+        neutral_hue=gr.themes.colors.slate,
+    ).set(
+        body_background_fill="#0f0f1a",
+        body_background_fill_dark="#0f0f1a",
+        block_background_fill="#1a1a2e",
+        block_background_fill_dark="#1a1a2e",
+        block_border_color="#2a2a4a",
+        block_border_color_dark="#2a2a4a",
+        input_background_fill="#16213e",
+        input_background_fill_dark="#16213e",
+        button_primary_background_fill="#1976d2",
+        button_primary_background_fill_dark="#1976d2",
+        button_primary_text_color="#ffffff",
+        button_secondary_background_fill="#2a2a4a",
+        button_secondary_background_fill_dark="#2a2a4a",
+        button_secondary_text_color="#ffffff",
     )
 
     with gr.Blocks(
-        title="EdgeTutor AI",
+        title="EdgeTutor AI — Your AI Lab",
         theme=theme,
         css="""
-        .edgetutor-header { text-align: center; margin-bottom: 10px; }
-        .edgetutor-header h1 { color: #1976d2; margin: 0; }
-        .edgetutor-header p { color: #666; margin: 5px 0; }
-        .status-bar { font-size: 0.85em; padding: 8px; background: #f5f5f5;
-                      border-radius: 8px; margin-bottom: 10px; }
-        footer { display: none !important; }
+        .header-box { text-align:center; padding:20px 10px 10px; }
+        .header-box h1 { color:#64b5f6; margin:0; font-size:2em; }
+        .header-box .subtitle { color:#90caf9; margin:4px 0; font-size:1.1em; }
+        .header-box .tagline { color:#666; font-size:0.85em; margin-top:4px; }
+        .status-bar { font-size:0.8em; padding:8px 12px; background:#1a1a2e;
+                      border-radius:10px; border:1px solid #2a2a4a; }
+        .mentor-topic-btn { min-height:60px !important; }
+        footer { display:none !important; }
+        .dark { --body-text-color: #e0e0e0; }
         """,
     ) as demo:
-        # State
-        chat_state = gr.State([])
+        # ── State ─────────────────────────────────────────────────────────
+        tutor_state = gr.State([])
+        mentor_state = gr.State([])
 
-        # Header
-        gr.HTML(
-            """
-            <div class="edgetutor-header">
-                <h1>🎓 EdgeTutor AI</h1>
-                <p>Your offline AI study buddy — powered by NVIDIA Jetson</p>
+        # ── Header ────────────────────────────────────────────────────────
+        gr.HTML("""
+        <div class="header-box">
+            <h1>🎓 EdgeTutor AI</h1>
+            <div class="subtitle">Welcome to Your AI Lab</div>
+            <div class="tagline">
+                Fully offline • Kid-safe • Powered by NVIDIA Jetson
             </div>
-            """
-        )
+        </div>
+        """)
 
-        # Module status bar
-        status_html = gr.HTML(
-            f'<div class="status-bar">{_get_module_status_html()}</div>'
-        )
+        # ── Module status ─────────────────────────────────────────────────
+        gr.HTML(f'<div class="status-bar">{_get_module_status_html()}</div>')
 
-        with gr.Row():
-            # ── LEFT: Chat + Input ────────────────────────────────────────
-            with gr.Column(scale=3):
-                chatbot = gr.Chatbot(
-                    label="EdgeTutor",
-                    height=480,
-                    type="messages",
-                    show_copy_button=True,
-                    avatar_images=(None, "https://em-content.zobj.net/source/twitter/376/graduation-cap_1f393.png"),
+        # ── Tabs ──────────────────────────────────────────────────────────
+        with gr.Tabs():
+            # ══════════════ TAB 1: AI TUTOR ═══════════════════════════════
+            with gr.TabItem("🎓 AI Tutor", id="tutor"):
+                with gr.Row():
+                    with gr.Column(scale=3):
+                        tutor_chatbot = gr.Chatbot(
+                            label="EdgeTutor",
+                            height=440,
+                            type="messages",
+                            show_copy_button=True,
+                        )
+                        with gr.Row():
+                            tutor_input = gr.Textbox(
+                                label="Ask EdgeTutor",
+                                placeholder="Type your question here...",
+                                scale=4, lines=1,
+                            )
+                            tutor_send = gr.Button("Send 📤", variant="primary", scale=1)
+
+                        with gr.Row():
+                            audio_input = gr.Audio(
+                                label="🎤 Push-to-Talk",
+                                sources=["microphone"], type="numpy", scale=2,
+                            )
+                            audio_output = gr.Audio(
+                                label="🔊 Response",
+                                type="numpy", autoplay=True, scale=2,
+                            )
+
+                    with gr.Column(scale=2):
+                        with gr.Accordion("📷 Camera / Image", open=True):
+                            image_input = gr.Image(
+                                label="Capture or upload worksheet",
+                                sources=["webcam", "upload"],
+                                type="pil", height=220,
+                            )
+                            with gr.Row():
+                                scan_btn = gr.Button("📄 Scan Worksheet", variant="secondary")
+                                explain_btn = gr.Button("📝 Step-by-Step", variant="secondary")
+
+                        with gr.Accordion("⚙️ Settings", open=False):
+                            age_slider = gr.Radio(
+                                choices=["7", "10", "16"], value="10",
+                                label="Age Mode",
+                                info="Adjusts tone and depth",
+                            )
+                            subject_dropdown = gr.Dropdown(
+                                choices=["math", "reading", "science", "general"],
+                                value="general", label="Subject",
+                            )
+                            parent_toggle = gr.Checkbox(
+                                label="🔓 Parent Mode (direct answers)", value=False,
+                            )
+                            quiz_toggle = gr.Checkbox(
+                                label="📝 Quiz Mode", value=False,
+                            )
+
+                # Tutor event handlers
+                tutor_inputs = [
+                    tutor_input, audio_input, image_input, tutor_state,
+                    age_slider, subject_dropdown, parent_toggle, quiz_toggle,
+                ]
+                tutor_outputs = [tutor_chatbot, tutor_state, audio_output, tutor_input]
+
+                tutor_send.click(fn=_chat_respond, inputs=tutor_inputs, outputs=tutor_outputs)
+                tutor_input.submit(fn=_chat_respond, inputs=tutor_inputs, outputs=tutor_outputs)
+                scan_btn.click(
+                    fn=_scan_worksheet,
+                    inputs=[image_input, tutor_state, age_slider, subject_dropdown, parent_toggle],
+                    outputs=[tutor_chatbot, tutor_state, audio_output],
+                )
+                explain_btn.click(
+                    fn=_explain_step_by_step,
+                    inputs=[tutor_state, age_slider, subject_dropdown, parent_toggle],
+                    outputs=[tutor_chatbot, tutor_state],
+                )
+
+            # ══════════════ TAB 2: AI MENTOR ══════════════════════════════
+            with gr.TabItem("🧠 AI Mentor", id="mentor"):
+                gr.Markdown(
+                    "### Learn How AI Works — On This Device!\n"
+                    "Pick a topic below or ask your own question. "
+                    "The AI Mentor will explain using the real hardware stats "
+                    "from your Jetson device."
                 )
 
                 with gr.Row():
-                    msg_input = gr.Textbox(
-                        label="Ask EdgeTutor",
-                        placeholder="Type your question here...",
-                        scale=4,
-                        lines=1,
-                    )
-                    send_btn = gr.Button("Send 📤", variant="primary", scale=1)
+                    with gr.Column(scale=3):
+                        mentor_chatbot = gr.Chatbot(
+                            label="AI Mentor",
+                            height=440,
+                            type="messages",
+                            show_copy_button=True,
+                        )
+                        with gr.Row():
+                            mentor_input = gr.Textbox(
+                                label="Ask the AI Mentor",
+                                placeholder="How do GPUs help with AI?",
+                                scale=4, lines=1,
+                            )
+                            mentor_send = gr.Button("Ask 🧠", variant="primary", scale=1)
 
-                with gr.Row():
-                    audio_input = gr.Audio(
-                        label="🎤 Push-to-Talk",
-                        sources=["microphone"],
-                        type="numpy",
-                        scale=2,
-                    )
-                    audio_output = gr.Audio(
-                        label="🔊 Tutor Response",
-                        type="numpy",
-                        autoplay=True,
-                        scale=2,
-                    )
+                    with gr.Column(scale=2):
+                        gr.Markdown("#### 📖 Explore Topics")
+                        mentor_topic = gr.State("none")
 
-            # ── RIGHT: Camera + Settings ──────────────────────────────────
-            with gr.Column(scale=2):
-                with gr.Accordion("📷 Camera / Image", open=True):
-                    image_input = gr.Image(
-                        label="Capture or upload worksheet",
-                        sources=["webcam", "upload"],
-                        type="pil",
-                        height=250,
-                    )
-                    with gr.Row():
-                        scan_btn = gr.Button("📄 Scan Worksheet", variant="secondary")
-                        explain_btn = gr.Button("📝 Explain Step-by-Step", variant="secondary")
+                        topic_buttons = {}
+                        topic_labels = {
+                            "this_device": "🖥️ About This Device",
+                            "gpu": "🎮 How GPUs Work",
+                            "cuda": "⚡ What is CUDA?",
+                            "llm": "🧠 How LLMs Work",
+                            "quantization": "📦 What is Quantization?",
+                            "neural_networks": "🕸️ Neural Networks",
+                            "edge_ai": "📡 What is Edge AI?",
+                            "whisper": "🎤 Speech Recognition",
+                            "ocr": "👁️ How OCR Works",
+                            "rag": "🔍 AI Search (RAG)",
+                        }
 
-                with gr.Accordion("⚙️ Settings", open=False):
-                    age_slider = gr.Radio(
-                        choices=["7", "10", "16"],
-                        value="10",
-                        label="Age Mode",
-                        info="Adjusts tone and explanation depth",
-                    )
-                    subject_dropdown = gr.Dropdown(
-                        choices=["math", "reading", "science", "general"],
-                        value="general",
-                        label="Subject Mode",
-                    )
-                    parent_toggle = gr.Checkbox(
-                        label="🔓 Parent Mode (direct answers)",
-                        value=False,
-                    )
-                    quiz_toggle = gr.Checkbox(
-                        label="📝 Quiz Mode (generate quizzes)",
-                        value=False,
-                    )
+                        for key, label in topic_labels.items():
+                            btn = gr.Button(label, variant="secondary", elem_classes=["mentor-topic-btn"])
+                            topic_buttons[key] = btn
 
-                with gr.Accordion("ℹ️ About", open=False):
-                    gr.Markdown(
-                        """
-                        **EdgeTutor AI v0.1.0**
+                        # Age selector for mentor
+                        mentor_age = gr.Radio(
+                            choices=["7", "10", "16"], value="10",
+                            label="Explanation Level",
+                        )
 
-                        - 🔒 Fully offline — no data leaves this device
-                        - 🛡️ Kid-safe guardrails enabled
-                        - 🧠 Powered by local LLM on NVIDIA Jetson
-                        - 📚 Add curriculum packs in the `content/` folder
+                        # System info panel
+                        gr.HTML(_get_system_info_html())
 
-                        [GitHub](https://github.com/thatcooperguy/edgetutor-ai)
-                        """
+                # Mentor event handlers
+                mentor_send.click(
+                    fn=_mentor_respond,
+                    inputs=[mentor_input, gr.State("none"), mentor_state, mentor_age],
+                    outputs=[mentor_chatbot, mentor_state, mentor_input],
+                )
+                mentor_input.submit(
+                    fn=_mentor_respond,
+                    inputs=[mentor_input, gr.State("none"), mentor_state, mentor_age],
+                    outputs=[mentor_chatbot, mentor_state, mentor_input],
+                )
+
+                # Topic button handlers
+                for topic_key, btn in topic_buttons.items():
+                    btn.click(
+                        fn=_mentor_respond,
+                        inputs=[gr.State(""), gr.State(topic_key), mentor_state, mentor_age],
+                        outputs=[mentor_chatbot, mentor_state, mentor_input],
                     )
 
-        # ── Event handlers ────────────────────────────────────────────────
-        send_inputs = [
-            msg_input, audio_input, image_input, chat_state,
-            age_slider, subject_dropdown, parent_toggle, quiz_toggle,
-        ]
-        send_outputs = [chatbot, chat_state, audio_output, msg_input]
+            # ══════════════ TAB 3: ABOUT ══════════════════════════════════
+            with gr.TabItem("ℹ️ About", id="about"):
+                gr.Markdown("""
+### EdgeTutor AI v0.1.0
 
-        send_btn.click(
-            fn=_chat_respond,
-            inputs=send_inputs,
-            outputs=send_outputs,
-        )
+**An offline-first AI Tutor + AI Mentor for NVIDIA Jetson.**
 
-        msg_input.submit(
-            fn=_chat_respond,
-            inputs=send_inputs,
-            outputs=send_outputs,
-        )
+| Feature | Status |
+|---------|--------|
+| 💬 Chat Tutor | ✅ Text-based tutoring |
+| 🎤 Voice Input | ✅ Push-to-talk (Whisper) |
+| 🔊 Voice Output | ✅ Text-to-speech (Piper) |
+| 📷 Worksheet Scanner | ✅ OCR + explanation |
+| 🔢 Math Detection | ✅ Auto-detect equations |
+| 🧠 AI Mentor | ✅ Learn about AI/GPUs/CUDA |
+| 📚 Content Packs | ✅ RAG with local docs |
+| 🛡️ Kid-Safe | ✅ Content filtering |
+| ⚡ Auto-Scaling | ✅ Adapts to your hardware |
 
-        scan_btn.click(
-            fn=_scan_worksheet,
-            inputs=[image_input, chat_state, age_slider, subject_dropdown, parent_toggle],
-            outputs=[chatbot, chat_state, audio_output],
-        )
+---
 
-        explain_btn.click(
-            fn=_explain_step_by_step,
-            inputs=[chat_state, age_slider, subject_dropdown, parent_toggle],
-            outputs=[chatbot, chat_state],
-        )
+**Privacy**: All processing happens locally on this device.
+No data is sent anywhere. No telemetry. No tracking.
+
+**Disclaimer**: This is an independent open-source project and is not
+affiliated with or endorsed by NVIDIA.
+
+[GitHub](https://github.com/thatcooperguy/Nvidia_Jetson_AI_Tutor) •
+[MIT License](https://github.com/thatcooperguy/Nvidia_Jetson_AI_Tutor/blob/main/LICENSE)
+                """)
 
     return demo
 
@@ -361,6 +498,6 @@ def launch_ui() -> None:
     demo.launch(
         server_name=cfg.host,
         server_port=cfg.port,
-        share=False,  # Offline device — no share link
+        share=False,
         show_error=True,
     )

--- a/edgetutor/app/ui.py
+++ b/edgetutor/app/ui.py
@@ -7,16 +7,24 @@ Dark theme. Supports: AI Tutor (streaming), AI Mentor, camera/voice, settings.
 
 from __future__ import annotations
 
+import uuid
+from typing import TYPE_CHECKING
+
 import gradio as gr
 
+from edgetutor.core.conversations import get_conversation_store
 from edgetutor.core.logging_config import get_logger
 from edgetutor.core.settings import get_settings
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 logger = get_logger(__name__)
 
 # ── Global state ──────────────────────────────────────────────────────────────
 _orchestrator = None
 _module_status = {}
+_conversation_store = None
 
 
 def _get_module_status_html() -> str:
@@ -75,8 +83,10 @@ def _get_system_info_html() -> str:
         return '<div style="color:#888">System info unavailable.</div>'
 
 
-def _build_conv_history(history: list | None, limit: int = 10) -> list[dict]:
+def _build_conv_history(history: list | None, limit: int | None = None) -> list[dict]:
     """Extract the last *limit* messages as [{role, content}] dicts."""
+    if limit is None:
+        limit = get_settings().conversation_history_limit
     conv = []
     for msg in (history or [])[-limit:]:
         if isinstance(msg, dict):
@@ -89,6 +99,15 @@ def _build_conv_history(history: list | None, limit: int = 10) -> list[dict]:
     return conv
 
 
+def _auto_save(session_id: str, history: list) -> None:
+    """Auto-save conversation history if store is available."""
+    if _conversation_store and session_id and history:
+        try:
+            _conversation_store.save(session_id, history)
+        except Exception as e:
+            logger.debug("Auto-save failed for %s: %s", session_id, e)
+
+
 def _format_errors(errors: list[str]) -> str:
     """Format orchestrator errors as a small HTML block."""
     if not errors:
@@ -97,12 +116,17 @@ def _format_errors(errors: list[str]) -> str:
     return f"\n\n<small>⚠️ **Warnings:**\n{lines}</small>"
 
 
+# ── Safety filter replacement sentinel ────────────────────────────────────────
+_SAFETY_REPLACE_MARKER = "\n\n[Response replaced by safety filter]"
+
+
 # ── Streaming chat handler ───────────────────────────────────────────────────
 def _chat_respond_stream(
     message: str,
     audio: tuple | None = None,
-    image: object | None = None,
+    image: Image.Image | None = None,
     history: list | None = None,
+    session_id: str = "",
     age_mode: str = "10",
     subject_mode: str = "general",
     parent_mode: bool = False,
@@ -118,7 +142,7 @@ def _chat_respond_stream(
 
     if _orchestrator is None:
         history.append({"role": "assistant", "content": "⚠️ System not initialized."})
-        yield history, history, None, ""
+        yield history, history, session_id, None, ""
         return
 
     from edgetutor.app.orchestrator import TutorRequest
@@ -162,20 +186,31 @@ def _chat_respond_stream(
     history.append({"role": "assistant", "content": ""})
 
     for token in _orchestrator.process_stream(request, conversation_history=conv_history):
+        # Handle safety filter replacement — replace the whole message
+        if _SAFETY_REPLACE_MARKER in token:
+            from edgetutor.core.safety import get_redirect_message
+
+            history[-1]["content"] = get_redirect_message()
+            yield history, history, session_id, None, ""
+            continue
+
         accumulated += token
         history[-1]["content"] = accumulated
-        yield history, history, None, ""
+        yield history, history, session_id, None, ""
+
+    # Auto-save conversation
+    _auto_save(session_id, history)
 
     # Final yield with complete text (no audio for streaming path)
-    yield history, history, None, ""
+    yield history, history, session_id, None, ""
 
 
 # ── Non-streaming fallback (used by worksheet scanner, step-by-step) ─────────
 def _chat_respond(
     message: str,
-    audio: tuple | None = None,
-    image: object | None = None,
+    image: Image.Image | None = None,
     history: list | None = None,
+    session_id: str = "",
     age_mode: str = "10",
     subject_mode: str = "general",
     parent_mode: bool = False,
@@ -187,7 +222,7 @@ def _chat_respond(
 
     if _orchestrator is None:
         history.append({"role": "assistant", "content": "⚠️ System not initialized."})
-        return history, history, None, ""
+        return history, history, session_id, None
 
     from edgetutor.app.orchestrator import TutorRequest
 
@@ -201,14 +236,6 @@ def _chat_respond(
         },
     )
 
-    if audio is not None:
-        try:
-            sr, audio_data = audio
-            request.audio_array = audio_data
-            request.audio_sample_rate = sr
-        except Exception as e:
-            logger.error("Audio processing error: %s", e)
-
     if image is not None:
         request.image = image
 
@@ -216,8 +243,6 @@ def _chat_respond(
     response = _orchestrator.process(request, conversation_history=conv_history)
 
     display_text = message
-    if not display_text and request.audio_array is not None:
-        display_text = "🎤 [Voice input]"
     if image is not None:
         display_text = (display_text or "") + " 📷 [Image attached]"
     if not display_text:
@@ -242,7 +267,11 @@ def _chat_respond(
         response_text += f"\n\n<small>⏱️ {' | '.join(latency_parts)}</small>"
 
     history.append({"role": "assistant", "content": response_text})
-    return history, history, response.audio, ""
+
+    # Auto-save conversation
+    _auto_save(session_id, history)
+
+    return history, history, session_id, response.audio
 
 
 # ── Mentor chat handler ───────────────────────────────────────────────────────
@@ -250,6 +279,7 @@ def _mentor_respond(
     message: str,
     mentor_topic: str,
     history: list | None = None,
+    session_id: str = "",
     age_mode: str = "10",
 ):
     """Chat handler for AI Mentor mode."""
@@ -258,7 +288,7 @@ def _mentor_respond(
 
     if _orchestrator is None or not _orchestrator.llm or not _orchestrator.llm.is_loaded:
         history.append({"role": "assistant", "content": "⚠️ LLM not loaded. Check models/ folder."})
-        return history, history, ""
+        return history, history, session_id, ""
 
     from edgetutor.core.mentor import build_mentor_prompt, get_mentor_topic_prompt
 
@@ -279,7 +309,7 @@ def _mentor_respond(
             display_text = message if message.strip() else f"📖 [Topic: {mentor_topic}]"
             history.append({"role": "user", "content": display_text})
             history.append({"role": "assistant", "content": get_redirect_message()})
-            return history, history, ""
+            return history, history, session_id, ""
 
     system_prompt = build_mentor_prompt(age=age_mode)
     conv_history = _build_conv_history(history)
@@ -294,30 +324,35 @@ def _mentor_respond(
     )
 
     history.append({"role": "assistant", "content": response_text})
-    return history, history, ""
+
+    # Auto-save conversation
+    _auto_save(session_id, history)
+
+    return history, history, session_id, ""
 
 
 # ── Worksheet scanner ─────────────────────────────────────────────────────────
-def _scan_worksheet(image, history, age_mode, subject_mode, parent_mode):
+def _scan_worksheet(image, history, session_id, age_mode, subject_mode, parent_mode):
     if image is None:
         history = history or []
         history.append({"role": "assistant", "content": "📷 Upload or capture an image first!"})
-        return history, history, None
+        return history, history, session_id, None
 
     return _chat_respond(
         message="Please explain this worksheet step by step.",
         image=image,
         history=history,
+        session_id=session_id,
         age_mode=age_mode,
         subject_mode=subject_mode,
         parent_mode=parent_mode,
-    )[:3]
+    )
 
 
-def _explain_step_by_step(history, age_mode, subject_mode, parent_mode):
+def _explain_step_by_step(history, session_id, age_mode, subject_mode, parent_mode):
     if not history:
         history = [{"role": "assistant", "content": "Ask me a question first!"}]
-        return history, history
+        return history, history, session_id
 
     last_user = ""
     for msg in reversed(history):
@@ -327,27 +362,29 @@ def _explain_step_by_step(history, age_mode, subject_mode, parent_mode):
 
     if not last_user:
         history.append({"role": "assistant", "content": "Ask me a question first!"})
-        return history, history
+        return history, history, session_id
 
     result = _chat_respond(
         message=f"Please explain this step by step in detail: {last_user}",
         history=history,
+        session_id=session_id,
         age_mode=age_mode,
         subject_mode=subject_mode,
         parent_mode=parent_mode,
     )
-    return result[0], result[1]
+    return result[0], result[1], result[2]
 
 
 # ── Build the full UI ─────────────────────────────────────────────────────────
 def build_ui() -> gr.Blocks:
     """Build the Gradio dark-themed interface with Tutor + Mentor tabs."""
-    global _orchestrator, _module_status
+    global _orchestrator, _module_status, _conversation_store
 
     from edgetutor.app.orchestrator import get_orchestrator
 
     _orchestrator = get_orchestrator()
     _module_status = _orchestrator.load_modules()
+    _conversation_store = get_conversation_store()
 
     # Dark theme
     theme = gr.themes.Base(
@@ -389,6 +426,8 @@ def build_ui() -> gr.Blocks:
         # ── State ─────────────────────────────────────────────────────────
         tutor_state = gr.State([])
         mentor_state = gr.State([])
+        tutor_session_id = gr.State(str(uuid.uuid4())[:8])
+        mentor_session_id = gr.State(str(uuid.uuid4())[:8])
 
         # ── Header ────────────────────────────────────────────────────────
         gr.HTML("""
@@ -478,12 +517,19 @@ def build_ui() -> gr.Blocks:
                     audio_input,
                     image_input,
                     tutor_state,
+                    tutor_session_id,
                     age_slider,
                     subject_dropdown,
                     parent_toggle,
                     quiz_toggle,
                 ]
-                tutor_outputs = [tutor_chatbot, tutor_state, audio_output, tutor_input]
+                tutor_outputs = [
+                    tutor_chatbot,
+                    tutor_state,
+                    tutor_session_id,
+                    audio_output,
+                    tutor_input,
+                ]
 
                 tutor_send.click(
                     fn=_chat_respond_stream,
@@ -497,13 +543,26 @@ def build_ui() -> gr.Blocks:
                 )
                 scan_btn.click(
                     fn=_scan_worksheet,
-                    inputs=[image_input, tutor_state, age_slider, subject_dropdown, parent_toggle],
-                    outputs=[tutor_chatbot, tutor_state, audio_output],
+                    inputs=[
+                        image_input,
+                        tutor_state,
+                        tutor_session_id,
+                        age_slider,
+                        subject_dropdown,
+                        parent_toggle,
+                    ],
+                    outputs=[tutor_chatbot, tutor_state, tutor_session_id, audio_output],
                 )
                 explain_btn.click(
                     fn=_explain_step_by_step,
-                    inputs=[tutor_state, age_slider, subject_dropdown, parent_toggle],
-                    outputs=[tutor_chatbot, tutor_state],
+                    inputs=[
+                        tutor_state,
+                        tutor_session_id,
+                        age_slider,
+                        subject_dropdown,
+                        parent_toggle,
+                    ],
+                    outputs=[tutor_chatbot, tutor_state, tutor_session_id],
                 )
 
             # ══════════════ TAB 2: AI MENTOR ══════════════════════════════
@@ -566,29 +625,55 @@ def build_ui() -> gr.Blocks:
                         gr.HTML(_get_system_info_html())
 
                 # Mentor event handlers
+                mentor_outputs = [
+                    mentor_chatbot,
+                    mentor_state,
+                    mentor_session_id,
+                    mentor_input,
+                ]
                 mentor_send.click(
                     fn=_mentor_respond,
-                    inputs=[mentor_input, gr.State("none"), mentor_state, mentor_age],
-                    outputs=[mentor_chatbot, mentor_state, mentor_input],
+                    inputs=[
+                        mentor_input,
+                        gr.State("none"),
+                        mentor_state,
+                        mentor_session_id,
+                        mentor_age,
+                    ],
+                    outputs=mentor_outputs,
                 )
                 mentor_input.submit(
                     fn=_mentor_respond,
-                    inputs=[mentor_input, gr.State("none"), mentor_state, mentor_age],
-                    outputs=[mentor_chatbot, mentor_state, mentor_input],
+                    inputs=[
+                        mentor_input,
+                        gr.State("none"),
+                        mentor_state,
+                        mentor_session_id,
+                        mentor_age,
+                    ],
+                    outputs=mentor_outputs,
                 )
 
                 # Topic button handlers
                 for topic_key, btn in topic_buttons.items():
                     btn.click(
                         fn=_mentor_respond,
-                        inputs=[gr.State(""), gr.State(topic_key), mentor_state, mentor_age],
-                        outputs=[mentor_chatbot, mentor_state, mentor_input],
+                        inputs=[
+                            gr.State(""),
+                            gr.State(topic_key),
+                            mentor_state,
+                            mentor_session_id,
+                            mentor_age,
+                        ],
+                        outputs=mentor_outputs,
                     )
 
             # ══════════════ TAB 3: ABOUT ══════════════════════════════════
             with gr.TabItem("ℹ️ About", id="about"):
-                gr.Markdown("""
-### EdgeTutor AI v0.1.0
+                from edgetutor import __version__
+
+                gr.Markdown(f"""
+### EdgeTutor AI v{__version__}
 
 **An offline-first AI Tutor + AI Mentor for NVIDIA Jetson.**
 

--- a/edgetutor/app/ui.py
+++ b/edgetutor/app/ui.py
@@ -44,6 +44,7 @@ def _get_system_info_html() -> str:
     """Generate system info panel HTML for AI Mentor mode."""
     try:
         from edgetutor.core.jetson import get_full_system_info
+
         info = get_full_system_info()
         return f"""
         <div style="font-family:monospace;font-size:0.85em;line-height:1.6;
@@ -52,20 +53,20 @@ def _get_system_info_html() -> str:
                 🖥️ YOUR AI LAB — System Stats
             </div>
             <table style="width:100%;color:#ccc">
-                <tr><td style="color:#888">Board</td><td><strong>{info['board_name']}</strong></td></tr>
-                <tr><td style="color:#888">GPU</td><td>{info['gpu_name']}</td></tr>
-                <tr><td style="color:#888">CUDA Cores</td><td>{info['cuda_cores']}</td></tr>
-                <tr><td style="color:#888">CPU Cores</td><td>{info['cpu_cores']}</td></tr>
-                <tr><td style="color:#888">RAM</td><td>{info['ram_total_gb']:.1f} GB total / {info['ram_available_gb']:.1f} GB free</td></tr>
-                <tr><td style="color:#888">GPU Memory</td><td>{info['gpu_mem_total_gb']:.1f} GB (shared)</td></tr>
-                <tr><td style="color:#888">Power Mode</td><td>{info['power_mode']}</td></tr>
-                <tr><td style="color:#888">Tegra</td><td>{'Yes ✓' if info['is_tegra'] else 'No'}</td></tr>
+                <tr><td style="color:#888">Board</td><td><strong>{info["board_name"]}</strong></td></tr>
+                <tr><td style="color:#888">GPU</td><td>{info["gpu_name"]}</td></tr>
+                <tr><td style="color:#888">CUDA Cores</td><td>{info["cuda_cores"]}</td></tr>
+                <tr><td style="color:#888">CPU Cores</td><td>{info["cpu_cores"]}</td></tr>
+                <tr><td style="color:#888">RAM</td><td>{info["ram_total_gb"]:.1f} GB total / {info["ram_available_gb"]:.1f} GB free</td></tr>
+                <tr><td style="color:#888">GPU Memory</td><td>{info["gpu_mem_total_gb"]:.1f} GB (shared)</td></tr>
+                <tr><td style="color:#888">Power Mode</td><td>{info["power_mode"]}</td></tr>
+                <tr><td style="color:#888">Tegra</td><td>{"Yes ✓" if info["is_tegra"] else "No"}</td></tr>
                 <tr><td colspan="2" style="border-top:1px solid #333;padding-top:6px"></td></tr>
-                <tr><td style="color:#888">Active LLM</td><td style="color:#76ff03">{info['recommended_model']}</td></tr>
-                <tr><td style="color:#888">GPU Layers</td><td>{info['recommended_gpu_layers']}</td></tr>
-                <tr><td style="color:#888">Context</td><td>{info['recommended_context']} tokens</td></tr>
-                <tr><td style="color:#888">STT Model</td><td>Whisper {info['recommended_stt']}</td></tr>
-                <tr><td style="color:#888">Scaling</td><td style="color:#ffc107;font-size:0.85em">{info['scaling_reason']}</td></tr>
+                <tr><td style="color:#888">Active LLM</td><td style="color:#76ff03">{info["recommended_model"]}</td></tr>
+                <tr><td style="color:#888">GPU Layers</td><td>{info["recommended_gpu_layers"]}</td></tr>
+                <tr><td style="color:#888">Context</td><td>{info["recommended_context"]} tokens</td></tr>
+                <tr><td style="color:#888">STT Model</td><td>Whisper {info["recommended_stt"]}</td></tr>
+                <tr><td style="color:#888">Scaling</td><td style="color:#ffc107;font-size:0.85em">{info["scaling_reason"]}</td></tr>
             </table>
         </div>
         """
@@ -119,10 +120,12 @@ def _chat_respond(
     conv_history = []
     for msg in (history or [])[-10:]:
         if isinstance(msg, dict):
-            conv_history.append({
-                "role": msg.get("role", "user"),
-                "content": msg.get("content", ""),
-            })
+            conv_history.append(
+                {
+                    "role": msg.get("role", "user"),
+                    "content": msg.get("content", ""),
+                }
+            )
 
     response = _orchestrator.process(request, conversation_history=conv_history)
 
@@ -180,10 +183,12 @@ def _mentor_respond(
     conv_history = []
     for msg in (history or [])[-10:]:
         if isinstance(msg, dict):
-            conv_history.append({
-                "role": msg.get("role", "user"),
-                "content": msg.get("content", ""),
-            })
+            conv_history.append(
+                {
+                    "role": msg.get("role", "user"),
+                    "content": msg.get("content", ""),
+                }
+            )
 
     display_text = message if message.strip() else f"📖 [Topic: {mentor_topic}]"
     history.append({"role": "user", "content": display_text})
@@ -207,8 +212,11 @@ def _scan_worksheet(image, history, age_mode, subject_mode, parent_mode):
 
     return _chat_respond(
         message="Please explain this worksheet step by step.",
-        image=image, history=history, age_mode=age_mode,
-        subject_mode=subject_mode, parent_mode=parent_mode,
+        image=image,
+        history=history,
+        age_mode=age_mode,
+        subject_mode=subject_mode,
+        parent_mode=parent_mode,
     )[:3]
 
 
@@ -229,8 +237,10 @@ def _explain_step_by_step(history, age_mode, subject_mode, parent_mode):
 
     result = _chat_respond(
         message=f"Please explain this step by step in detail: {last_user}",
-        history=history, age_mode=age_mode,
-        subject_mode=subject_mode, parent_mode=parent_mode,
+        history=history,
+        age_mode=age_mode,
+        subject_mode=subject_mode,
+        parent_mode=parent_mode,
     )
     return result[0], result[1]
 
@@ -241,6 +251,7 @@ def build_ui() -> gr.Blocks:
     global _orchestrator, _module_status
 
     from edgetutor.app.orchestrator import get_orchestrator
+
     _orchestrator = get_orchestrator()
     _module_status = _orchestrator.load_modules()
 
@@ -315,18 +326,23 @@ def build_ui() -> gr.Blocks:
                             tutor_input = gr.Textbox(
                                 label="Ask EdgeTutor",
                                 placeholder="Type your question here...",
-                                scale=4, lines=1,
+                                scale=4,
+                                lines=1,
                             )
                             tutor_send = gr.Button("Send 📤", variant="primary", scale=1)
 
                         with gr.Row():
                             audio_input = gr.Audio(
                                 label="🎤 Push-to-Talk",
-                                sources=["microphone"], type="numpy", scale=2,
+                                sources=["microphone"],
+                                type="numpy",
+                                scale=2,
                             )
                             audio_output = gr.Audio(
                                 label="🔊 Response",
-                                type="numpy", autoplay=True, scale=2,
+                                type="numpy",
+                                autoplay=True,
+                                scale=2,
                             )
 
                     with gr.Column(scale=2):
@@ -334,7 +350,8 @@ def build_ui() -> gr.Blocks:
                             image_input = gr.Image(
                                 label="Capture or upload worksheet",
                                 sources=["webcam", "upload"],
-                                type="pil", height=220,
+                                type="pil",
+                                height=220,
                             )
                             with gr.Row():
                                 scan_btn = gr.Button("📄 Scan Worksheet", variant="secondary")
@@ -342,25 +359,35 @@ def build_ui() -> gr.Blocks:
 
                         with gr.Accordion("⚙️ Settings", open=False):
                             age_slider = gr.Radio(
-                                choices=["7", "10", "16"], value="10",
+                                choices=["7", "10", "16"],
+                                value="10",
                                 label="Age Mode",
                                 info="Adjusts tone and depth",
                             )
                             subject_dropdown = gr.Dropdown(
                                 choices=["math", "reading", "science", "general"],
-                                value="general", label="Subject",
+                                value="general",
+                                label="Subject",
                             )
                             parent_toggle = gr.Checkbox(
-                                label="🔓 Parent Mode (direct answers)", value=False,
+                                label="🔓 Parent Mode (direct answers)",
+                                value=False,
                             )
                             quiz_toggle = gr.Checkbox(
-                                label="📝 Quiz Mode", value=False,
+                                label="📝 Quiz Mode",
+                                value=False,
                             )
 
                 # Tutor event handlers
                 tutor_inputs = [
-                    tutor_input, audio_input, image_input, tutor_state,
-                    age_slider, subject_dropdown, parent_toggle, quiz_toggle,
+                    tutor_input,
+                    audio_input,
+                    image_input,
+                    tutor_state,
+                    age_slider,
+                    subject_dropdown,
+                    parent_toggle,
+                    quiz_toggle,
                 ]
                 tutor_outputs = [tutor_chatbot, tutor_state, audio_output, tutor_input]
 
@@ -398,7 +425,8 @@ def build_ui() -> gr.Blocks:
                             mentor_input = gr.Textbox(
                                 label="Ask the AI Mentor",
                                 placeholder="How do GPUs help with AI?",
-                                scale=4, lines=1,
+                                scale=4,
+                                lines=1,
                             )
                             mentor_send = gr.Button("Ask 🧠", variant="primary", scale=1)
 
@@ -420,12 +448,15 @@ def build_ui() -> gr.Blocks:
                         }
 
                         for key, label in topic_labels.items():
-                            btn = gr.Button(label, variant="secondary", elem_classes=["mentor-topic-btn"])
+                            btn = gr.Button(
+                                label, variant="secondary", elem_classes=["mentor-topic-btn"]
+                            )
                             topic_buttons[key] = btn
 
                         # Age selector for mentor
                         mentor_age = gr.Radio(
-                            choices=["7", "10", "16"], value="10",
+                            choices=["7", "10", "16"],
+                            value="10",
                             label="Explanation Level",
                         )
 

--- a/edgetutor/app/ui.py
+++ b/edgetutor/app/ui.py
@@ -404,7 +404,6 @@ def build_ui() -> gr.Blocks:
 
                     with gr.Column(scale=2):
                         gr.Markdown("#### 📖 Explore Topics")
-                        mentor_topic = gr.State("none")
 
                         topic_buttons = {}
                         topic_labels = {

--- a/edgetutor/app/ui.py
+++ b/edgetutor/app/ui.py
@@ -2,7 +2,7 @@
 EdgeTutor AI — Gradio Web UI.
 
 Local web interface served on LAN (default localhost:7860).
-Dark theme. Supports: AI Tutor, AI Mentor, camera/voice, settings.
+Dark theme. Supports: AI Tutor (streaming), AI Mentor, camera/voice, settings.
 """
 
 from __future__ import annotations
@@ -75,18 +75,113 @@ def _get_system_info_html() -> str:
         return '<div style="color:#888">System info unavailable.</div>'
 
 
-# ── Chat handler ──────────────────────────────────────────────────────────────
-def _chat_respond(
+def _build_conv_history(history: list | None, limit: int = 10) -> list[dict]:
+    """Extract the last *limit* messages as [{role, content}] dicts."""
+    conv = []
+    for msg in (history or [])[-limit:]:
+        if isinstance(msg, dict):
+            conv.append(
+                {
+                    "role": msg.get("role", "user"),
+                    "content": msg.get("content", ""),
+                }
+            )
+    return conv
+
+
+def _format_errors(errors: list[str]) -> str:
+    """Format orchestrator errors as a small HTML block."""
+    if not errors:
+        return ""
+    lines = "\n".join(f"- {e}" for e in errors)
+    return f"\n\n<small>⚠️ **Warnings:**\n{lines}</small>"
+
+
+# ── Streaming chat handler ───────────────────────────────────────────────────
+def _chat_respond_stream(
     message: str,
     audio: tuple | None = None,
     image: object | None = None,
-    history: list = None,
+    history: list | None = None,
     age_mode: str = "10",
     subject_mode: str = "general",
     parent_mode: bool = False,
     quiz_mode: bool = False,
 ):
-    """Main chat handler for AI Tutor mode."""
+    """Streaming chat handler for AI Tutor mode.
+
+    This is a *generator* — Gradio calls it and yields partial chat
+    histories so the user sees tokens appear in real time.
+    """
+    if history is None:
+        history = []
+
+    if _orchestrator is None:
+        history.append({"role": "assistant", "content": "⚠️ System not initialized."})
+        yield history, history, None, ""
+        return
+
+    from edgetutor.app.orchestrator import TutorRequest
+
+    request = TutorRequest(
+        user_text=message or "",
+        settings_override={
+            "age_mode": age_mode,
+            "subject_mode": subject_mode,
+            "parent_mode": parent_mode,
+            "quiz_mode": quiz_mode,
+        },
+    )
+
+    if audio is not None:
+        try:
+            sr, audio_data = audio
+            request.audio_array = audio_data
+            request.audio_sample_rate = sr
+        except Exception as e:
+            logger.error("Audio processing error: %s", e)
+
+    if image is not None:
+        request.image = image
+
+    conv_history = _build_conv_history(history)
+
+    # ── Add user message to history ──────────────────────────────────
+    display_text = message
+    if not display_text and request.audio_array is not None:
+        display_text = "🎤 [Voice input]"
+    if image is not None:
+        display_text = (display_text or "") + " 📷 [Image attached]"
+    if not display_text:
+        display_text = "..."
+
+    history.append({"role": "user", "content": display_text.strip()})
+
+    # ── Stream tokens from the orchestrator ──────────────────────────
+    accumulated = ""
+    history.append({"role": "assistant", "content": ""})
+
+    for token in _orchestrator.process_stream(request, conversation_history=conv_history):
+        accumulated += token
+        history[-1]["content"] = accumulated
+        yield history, history, None, ""
+
+    # Final yield with complete text (no audio for streaming path)
+    yield history, history, None, ""
+
+
+# ── Non-streaming fallback (used by worksheet scanner, step-by-step) ─────────
+def _chat_respond(
+    message: str,
+    audio: tuple | None = None,
+    image: object | None = None,
+    history: list | None = None,
+    age_mode: str = "10",
+    subject_mode: str = "general",
+    parent_mode: bool = False,
+    quiz_mode: bool = False,
+):
+    """Non-streaming chat handler (used for worksheet scans, etc.)."""
     if history is None:
         history = []
 
@@ -117,16 +212,7 @@ def _chat_respond(
     if image is not None:
         request.image = image
 
-    conv_history = []
-    for msg in (history or [])[-10:]:
-        if isinstance(msg, dict):
-            conv_history.append(
-                {
-                    "role": msg.get("role", "user"),
-                    "content": msg.get("content", ""),
-                }
-            )
-
+    conv_history = _build_conv_history(history)
     response = _orchestrator.process(request, conversation_history=conv_history)
 
     display_text = message
@@ -141,10 +227,15 @@ def _chat_respond(
 
     response_text = response.text
     if response.ocr_text:
-        response_text = f"📝 **Extracted text:**\n> {response.ocr_text[:300]}{'...' if len(response.ocr_text) > 300 else ''}\n\n{response_text}"
+        preview = response.ocr_text[:300]
+        ellipsis = "..." if len(response.ocr_text) > 300 else ""
+        response_text = f"📝 **Extracted text:**\n> {preview}{ellipsis}\n\n{response_text}"
     if response.has_math and response.math_expressions:
         math_preview = "\n".join(f"- `{expr}`" for expr in response.math_expressions[:5])
         response_text = f"🔢 **Math detected:**\n{math_preview}\n\n{response_text}"
+
+    # Surface errors from orchestrator
+    response_text += _format_errors(response.errors)
 
     latency_parts = [f"{k}: {v:.1f}s" for k, v in response.latency.items()]
     if latency_parts:
@@ -158,14 +249,14 @@ def _chat_respond(
 def _mentor_respond(
     message: str,
     mentor_topic: str,
-    history: list = None,
+    history: list | None = None,
     age_mode: str = "10",
 ):
     """Chat handler for AI Mentor mode."""
     if history is None:
         history = []
 
-    if _orchestrator is None or not _orchestrator._llm or not _orchestrator._llm.is_loaded:
+    if _orchestrator is None or not _orchestrator.llm or not _orchestrator.llm.is_loaded:
         history.append({"role": "assistant", "content": "⚠️ LLM not loaded. Check models/ folder."})
         return history, history, ""
 
@@ -178,22 +269,25 @@ def _mentor_respond(
     elif not actual_message.strip():
         actual_message = "Tell me about this Jetson device and how AI works on it!"
 
-    system_prompt = build_mentor_prompt(age=age_mode)
+    # Safety check on mentor input
+    cfg = get_settings()
+    if cfg.safety_enabled:
+        from edgetutor.core.safety import check_input_safety, get_redirect_message
 
-    conv_history = []
-    for msg in (history or [])[-10:]:
-        if isinstance(msg, dict):
-            conv_history.append(
-                {
-                    "role": msg.get("role", "user"),
-                    "content": msg.get("content", ""),
-                }
-            )
+        is_safe, _category = check_input_safety(actual_message)
+        if not is_safe:
+            display_text = message if message.strip() else f"📖 [Topic: {mentor_topic}]"
+            history.append({"role": "user", "content": display_text})
+            history.append({"role": "assistant", "content": get_redirect_message()})
+            return history, history, ""
+
+    system_prompt = build_mentor_prompt(age=age_mode)
+    conv_history = _build_conv_history(history)
 
     display_text = message if message.strip() else f"📖 [Topic: {mentor_topic}]"
     history.append({"role": "user", "content": display_text})
 
-    response_text = _orchestrator._llm.generate(
+    response_text = _orchestrator.llm.generate(
         user_message=actual_message,
         system_prompt=system_prompt,
         conversation_history=conv_history,
@@ -378,7 +472,7 @@ def build_ui() -> gr.Blocks:
                                 value=False,
                             )
 
-                # Tutor event handlers
+                # Tutor event handlers — streaming for text, non-streaming for scans
                 tutor_inputs = [
                     tutor_input,
                     audio_input,
@@ -391,8 +485,16 @@ def build_ui() -> gr.Blocks:
                 ]
                 tutor_outputs = [tutor_chatbot, tutor_state, audio_output, tutor_input]
 
-                tutor_send.click(fn=_chat_respond, inputs=tutor_inputs, outputs=tutor_outputs)
-                tutor_input.submit(fn=_chat_respond, inputs=tutor_inputs, outputs=tutor_outputs)
+                tutor_send.click(
+                    fn=_chat_respond_stream,
+                    inputs=tutor_inputs,
+                    outputs=tutor_outputs,
+                )
+                tutor_input.submit(
+                    fn=_chat_respond_stream,
+                    inputs=tutor_inputs,
+                    outputs=tutor_outputs,
+                )
                 scan_btn.click(
                     fn=_scan_worksheet,
                     inputs=[image_input, tutor_state, age_slider, subject_dropdown, parent_toggle],

--- a/edgetutor/audio/stt.py
+++ b/edgetutor/audio/stt.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Optional
 
 from edgetutor.core.logging_config import get_logger
 from edgetutor.core.settings import get_settings
@@ -84,7 +83,7 @@ class STTEngine:
     def transcribe(
         self,
         audio_path: str | Path,
-        language: Optional[str] = None,
+        language: str | None = None,
     ) -> dict:
         """
         Transcribe an audio file.
@@ -154,7 +153,7 @@ class STTEngine:
         self,
         audio_array,
         sample_rate: int = 16000,
-        language: Optional[str] = None,
+        language: str | None = None,
     ) -> dict:
         """
         Transcribe from a numpy array (e.g., from Gradio audio input).

--- a/edgetutor/audio/stt.py
+++ b/edgetutor/audio/stt.py
@@ -167,7 +167,13 @@ class STTEngine:
             Same dict as transcribe().
         """
         if not self._ready or self.model is None:
-            return {"text": "", "language": "", "duration_s": 0.0, "elapsed_s": 0.0, "error": "STT not loaded"}
+            return {
+                "text": "",
+                "language": "",
+                "duration_s": 0.0,
+                "elapsed_s": 0.0,
+                "error": "STT not loaded",
+            }
 
         import numpy as np
 
@@ -209,7 +215,13 @@ class STTEngine:
 
         except Exception as e:
             logger.error("STT numpy transcription failed: %s", e)
-            return {"text": "", "language": "", "duration_s": 0.0, "elapsed_s": 0.0, "error": str(e)}
+            return {
+                "text": "",
+                "language": "",
+                "duration_s": 0.0,
+                "elapsed_s": 0.0,
+                "error": str(e),
+            }
 
 
 def get_stt() -> STTEngine:

--- a/edgetutor/audio/tts.py
+++ b/edgetutor/audio/tts.py
@@ -8,11 +8,9 @@ Outputs WAV audio that can be played in the Gradio UI or saved to file.
 from __future__ import annotations
 
 import io
-import struct
 import time
 import wave
 from pathlib import Path
-from typing import Optional
 
 from edgetutor.core.logging_config import get_logger
 from edgetutor.core.settings import get_settings
@@ -76,7 +74,7 @@ class TTSEngine:
             logger.error("Failed to load TTS voice: %s", e)
             return False
 
-    def synthesize(self, text: str) -> Optional[bytes]:
+    def synthesize(self, text: str) -> bytes | None:
         """
         Synthesize text to WAV audio bytes.
 
@@ -144,7 +142,7 @@ class TTSEngine:
             logger.error("Failed to save TTS audio: %s", e)
             return False
 
-    def get_audio_tuple(self, text: str) -> Optional[tuple]:
+    def get_audio_tuple(self, text: str) -> tuple | None:
         """
         Synthesize and return (sample_rate, numpy_array) for Gradio.
 

--- a/edgetutor/core/conversations.py
+++ b/edgetutor/core/conversations.py
@@ -1,0 +1,120 @@
+"""
+EdgeTutor AI — Conversation persistence.
+
+Simple JSON-based save/load for chat histories. Conversations are stored
+in a configurable directory (default: ~/.edgetutor/conversations/).
+
+This keeps chat history available across page refreshes and app restarts
+while staying fully offline — no database required.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from edgetutor.core.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Default storage location
+_DEFAULT_DIR = Path.home() / ".edgetutor" / "conversations"
+
+
+class ConversationStore:
+    """Persist and retrieve chat conversations as JSON files."""
+
+    def __init__(self, storage_dir: Path | str | None = None):
+        self._dir = Path(storage_dir) if storage_dir else _DEFAULT_DIR
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def storage_dir(self) -> Path:
+        return self._dir
+
+    def save(self, session_id: str, history: list[dict]) -> Path:
+        """
+        Save a conversation history to disk.
+
+        Args:
+            session_id: Unique identifier for this conversation.
+            history: List of message dicts [{"role": ..., "content": ...}].
+
+        Returns:
+            Path to the saved JSON file.
+        """
+        path = self._dir / f"{session_id}.json"
+        data = {
+            "session_id": session_id,
+            "updated_at": time.time(),
+            "messages": history,
+        }
+        try:
+            path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+            logger.debug("Saved conversation %s (%d messages)", session_id, len(history))
+        except Exception as e:
+            logger.error("Failed to save conversation %s: %s", session_id, e)
+        return path
+
+    def load(self, session_id: str) -> list[dict]:
+        """
+        Load a conversation history from disk.
+
+        Returns an empty list if the file doesn't exist or is corrupt.
+        """
+        path = self._dir / f"{session_id}.json"
+        if not path.exists():
+            return []
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            messages = data.get("messages", [])
+            logger.debug("Loaded conversation %s (%d messages)", session_id, len(messages))
+            return messages
+        except Exception as e:
+            logger.error("Failed to load conversation %s: %s", session_id, e)
+            return []
+
+    def list_sessions(self) -> list[dict]:
+        """
+        List all saved sessions, sorted by most recent first.
+
+        Returns:
+            List of dicts with keys: session_id, updated_at, message_count.
+        """
+        sessions = []
+        for path in self._dir.glob("*.json"):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                sessions.append(
+                    {
+                        "session_id": data.get("session_id", path.stem),
+                        "updated_at": data.get("updated_at", 0),
+                        "message_count": len(data.get("messages", [])),
+                    }
+                )
+            except Exception:
+                continue
+        sessions.sort(key=lambda s: s["updated_at"], reverse=True)
+        return sessions
+
+    def delete(self, session_id: str) -> bool:
+        """Delete a conversation file. Returns True if deleted."""
+        path = self._dir / f"{session_id}.json"
+        if path.exists():
+            path.unlink()
+            logger.debug("Deleted conversation %s", session_id)
+            return True
+        return False
+
+
+# Module-level singleton
+_store_instance: ConversationStore | None = None
+
+
+def get_conversation_store() -> ConversationStore:
+    """Return the singleton ConversationStore."""
+    global _store_instance
+    if _store_instance is None:
+        _store_instance = ConversationStore()
+    return _store_instance

--- a/edgetutor/core/jetson.py
+++ b/edgetutor/core/jetson.py
@@ -12,7 +12,6 @@ import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 from edgetutor.core.logging_config import get_logger
 

--- a/edgetutor/core/jetson.py
+++ b/edgetutor/core/jetson.py
@@ -437,30 +437,127 @@ def recommend_model_for_available_memory() -> dict:
     }
 
 
-def print_system_info() -> None:
-    """Print system info summary (for setup scripts and debugging)."""
+def get_cpu_cores() -> int:
+    """Get the number of CPU cores."""
+    try:
+        return os.cpu_count() or 1
+    except Exception:
+        return 1
+
+
+def get_power_mode() -> str:
+    """
+    Get the current NVPModel power mode on Jetson.
+
+    Returns a string like "MAXN", "15W", "7W", or "unknown".
+    """
+    try:
+        result = subprocess.run(
+            ["nvpmodel", "-q"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.split("\n"):
+                if "NV Power Mode" in line or "POWER_MODEL" in line:
+                    return line.split(":")[-1].strip()
+                if "mode:" in line.lower():
+                    return line.split(":")[-1].strip()
+            # If we got output but couldn't parse, return the first line
+            return result.stdout.strip().split("\n")[0][:40]
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return "unknown"
+
+
+def get_jetson_clocks_status() -> str:
+    """Check if jetson_clocks is active (max performance)."""
+    try:
+        result = subprocess.run(
+            ["jetson_clocks", "--show"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            return "active"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return "unknown"
+
+
+def is_tegra_device() -> bool:
+    """Check if running on any NVIDIA Tegra-based device (Jetson, Spark, etc.)."""
+    indicators = [
+        "/etc/nv_tegra_release",
+        "/proc/device-tree/compatible",
+    ]
+    for path in indicators:
+        if os.path.exists(path):
+            try:
+                with open(path) as f:
+                    content = f.read().lower()
+                if "tegra" in content or "nvidia" in content:
+                    return True
+            except (PermissionError, UnicodeDecodeError):
+                if os.path.exists(path):
+                    return True  # File exists, likely Tegra
+    return False
+
+
+def get_full_system_info() -> dict:
+    """
+    Collect comprehensive system information as a dict.
+
+    Used by the AI Mentor mode and system diagnostics.
+    """
     profile = get_board_profile()
     total = get_total_ram_gb()
     available = get_available_ram_gb()
     gpu_total, gpu_free = get_gpu_memory_gb()
     rec = recommend_model_for_available_memory()
 
+    return {
+        "board_name": profile.name,
+        "gpu_name": profile.gpu_name,
+        "cuda_cores": profile.cuda_cores,
+        "cpu_cores": get_cpu_cores(),
+        "ram_total_gb": total,
+        "ram_available_gb": available,
+        "gpu_mem_total_gb": gpu_total,
+        "gpu_mem_free_gb": gpu_free,
+        "unified_memory": profile.gpu_ram_shared,
+        "power_mode": get_power_mode(),
+        "jetson_clocks": get_jetson_clocks_status(),
+        "is_tegra": is_tegra_device(),
+        "recommended_model": rec["model"],
+        "recommended_gpu_layers": rec["gpu_layers"],
+        "recommended_context": rec["context_size"],
+        "recommended_stt": rec["stt_model"],
+        "scaling_reason": rec["reason"],
+        "profile_notes": profile.notes,
+    }
+
+
+def print_system_info() -> None:
+    """Print system info summary (for setup scripts and debugging)."""
+    info = get_full_system_info()
+
     print("=" * 60)
     print("  EdgeTutor AI — System Information")
     print("=" * 60)
-    print(f"  Board:          {profile.name}")
-    print(f"  GPU:            {profile.gpu_name}")
-    print(f"  CUDA cores:     {profile.cuda_cores}")
-    print(f"  RAM:            {total:.1f} GB total, {available:.1f} GB available")
-    print(f"  GPU memory:     {gpu_total:.1f} GB total, {gpu_free:.1f} GB free (shared)")
-    print(f"  Unified memory: {'Yes' if profile.gpu_ram_shared else 'No'}")
+    print(f"  Board:          {info['board_name']}")
+    print(f"  GPU:            {info['gpu_name']}")
+    print(f"  CUDA cores:     {info['cuda_cores']}")
+    print(f"  CPU cores:      {info['cpu_cores']}")
+    print(f"  RAM:            {info['ram_total_gb']:.1f} GB total, {info['ram_available_gb']:.1f} GB available")
+    print(f"  GPU memory:     {info['gpu_mem_total_gb']:.1f} GB total, {info['gpu_mem_free_gb']:.1f} GB free")
+    print(f"  Unified memory: {'Yes' if info['unified_memory'] else 'No'}")
+    print(f"  Power mode:     {info['power_mode']}")
+    print(f"  Tegra device:   {'Yes' if info['is_tegra'] else 'No'}")
     print()
     print("  Recommended configuration:")
-    print(f"    LLM model:      {rec['model']}")
-    print(f"    GPU layers:     {rec['gpu_layers']}")
-    print(f"    Context size:   {rec['context_size']}")
-    print(f"    STT model:      {rec['stt_model']}")
-    print(f"    STT compute:    {rec['stt_compute']}")
-    print(f"    Reason:         {rec['reason']}")
-    print(f"  Notes: {profile.notes}")
+    print(f"    LLM model:      {info['recommended_model']}")
+    print(f"    GPU layers:     {info['recommended_gpu_layers']}")
+    print(f"    Context size:   {info['recommended_context']}")
+    print(f"    STT model:      {info['recommended_stt']}")
+    print(f"    Reason:         {info['scaling_reason']}")
+    print(f"  Notes: {info['profile_notes']}")
     print("=" * 60)

--- a/edgetutor/core/jetson.py
+++ b/edgetutor/core/jetson.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import os
 import subprocess
 from dataclasses import dataclass
-from pathlib import Path
 
 from edgetutor.core.logging_config import get_logger
 

--- a/edgetutor/core/jetson.py
+++ b/edgetutor/core/jetson.py
@@ -282,7 +282,9 @@ def get_gpu_memory_gb() -> tuple[float, float]:
     try:
         result = subprocess.run(
             ["nvidia-smi", "--query-gpu=memory.total,memory.free", "--format=csv,nounits,noheader"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         if result.returncode == 0:
             parts = result.stdout.strip().split(",")
@@ -348,7 +350,9 @@ def detect_jetson_board() -> str:
     # Not a Jetson — check for GPU
     try:
         result = subprocess.run(
-            ["nvidia-smi"], capture_output=True, timeout=5,
+            ["nvidia-smi"],
+            capture_output=True,
+            timeout=5,
         )
         if result.returncode == 0:
             return "generic_gpu"
@@ -403,7 +407,10 @@ def recommend_model_for_available_memory() -> dict:
         if usable >= required:
             logger.info(
                 "Recommended model: %s (%.1f GB, need %.1f GB, have %.1f GB usable)",
-                tier["name"], tier["size_gb"], required, usable,
+                tier["name"],
+                tier["size_gb"],
+                required,
+                usable,
             )
             # Adjust GPU layers based on available memory
             gpu_layers = 20
@@ -452,7 +459,9 @@ def get_power_mode() -> str:
     try:
         result = subprocess.run(
             ["nvpmodel", "-q"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         if result.returncode == 0:
             for line in result.stdout.split("\n"):
@@ -472,7 +481,9 @@ def get_jetson_clocks_status() -> str:
     try:
         result = subprocess.run(
             ["jetson_clocks", "--show"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         if result.returncode == 0:
             return "active"
@@ -545,8 +556,12 @@ def print_system_info() -> None:
     print(f"  GPU:            {info['gpu_name']}")
     print(f"  CUDA cores:     {info['cuda_cores']}")
     print(f"  CPU cores:      {info['cpu_cores']}")
-    print(f"  RAM:            {info['ram_total_gb']:.1f} GB total, {info['ram_available_gb']:.1f} GB available")
-    print(f"  GPU memory:     {info['gpu_mem_total_gb']:.1f} GB total, {info['gpu_mem_free_gb']:.1f} GB free")
+    print(
+        f"  RAM:            {info['ram_total_gb']:.1f} GB total, {info['ram_available_gb']:.1f} GB available"
+    )
+    print(
+        f"  GPU memory:     {info['gpu_mem_total_gb']:.1f} GB total, {info['gpu_mem_free_gb']:.1f} GB free"
+    )
     print(f"  Unified memory: {'Yes' if info['unified_memory'] else 'No'}")
     print(f"  Power mode:     {info['power_mode']}")
     print(f"  Tegra device:   {'Yes' if info['is_tegra'] else 'No'}")

--- a/edgetutor/core/llm.py
+++ b/edgetutor/core/llm.py
@@ -8,7 +8,7 @@ system prompt injection, and safety filtering.
 from __future__ import annotations
 
 import time
-from typing import Generator, Optional
+from collections.abc import Generator
 
 from edgetutor.core.logging_config import get_logger
 from edgetutor.core.prompts import build_system_prompt
@@ -74,10 +74,10 @@ class LLMBackend:
     def generate(
         self,
         user_message: str,
-        system_prompt: Optional[str] = None,
-        conversation_history: Optional[list[dict]] = None,
-        max_tokens: Optional[int] = None,
-        temperature: Optional[float] = None,
+        system_prompt: str | None = None,
+        conversation_history: list[dict] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
     ) -> str:
         """
         Generate a complete response (non-streaming).
@@ -144,10 +144,10 @@ class LLMBackend:
     def generate_stream(
         self,
         user_message: str,
-        system_prompt: Optional[str] = None,
-        conversation_history: Optional[list[dict]] = None,
-        max_tokens: Optional[int] = None,
-        temperature: Optional[float] = None,
+        system_prompt: str | None = None,
+        conversation_history: list[dict] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
     ) -> Generator[str, None, None]:
         """
         Stream tokens one-by-one (generator).

--- a/edgetutor/core/llm.py
+++ b/edgetutor/core/llm.py
@@ -61,7 +61,9 @@ class LLMBackend:
             )
             return True
         except ImportError:
-            logger.error("llama-cpp-python not installed. Install with: pip install llama-cpp-python")
+            logger.error(
+                "llama-cpp-python not installed. Install with: pip install llama-cpp-python"
+            )
             return False
         except Exception as e:
             logger.error("Failed to load LLM: %s", e)

--- a/edgetutor/core/logging_config.py
+++ b/edgetutor/core/logging_config.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import logging
 import sys
 from logging.handlers import RotatingFileHandler
-from pathlib import Path
 
 from edgetutor.core.settings import get_settings
 

--- a/edgetutor/core/mentor.py
+++ b/edgetutor/core/mentor.py
@@ -142,6 +142,7 @@ def get_system_stats_text() -> str:
         avail_ram = get_available_ram_gb()
 
         from edgetutor.core.settings import get_settings
+
         cfg = get_settings()
 
         stats = [
@@ -178,10 +179,7 @@ def build_mentor_prompt(age: str = "10") -> str:
 
 def get_mentor_topic_list() -> list[dict]:
     """Return the list of mentor topics for the UI."""
-    return [
-        {"key": key, "title": info["title"]}
-        for key, info in MENTOR_TOPICS.items()
-    ]
+    return [{"key": key, "title": info["title"]} for key, info in MENTOR_TOPICS.items()]
 
 
 def get_mentor_topic_prompt(topic_key: str) -> str:

--- a/edgetutor/core/mentor.py
+++ b/edgetutor/core/mentor.py
@@ -8,8 +8,8 @@ It turns the device itself into a learning lab.
 
 from __future__ import annotations
 
+from edgetutor.core.jetson import get_available_ram_gb, get_board_profile, get_total_ram_gb
 from edgetutor.core.logging_config import get_logger
-from edgetutor.core.jetson import get_board_profile, get_total_ram_gb, get_available_ram_gb
 
 logger = get_logger(__name__)
 
@@ -149,13 +149,13 @@ def get_system_stats_text() -> str:
             f"GPU: {profile.gpu_name}",
             f"CUDA Cores: {profile.cuda_cores}",
             f"RAM: {total_ram:.1f} GB total, {avail_ram:.1f} GB available",
-            f"Memory type: Unified (shared between CPU and GPU)",
+            "Memory type: Unified (shared between CPU and GPU)",
             f"LLM model: {cfg.llm_model_path}",
             f"LLM GPU layers: {cfg.llm_n_gpu_layers}",
             f"LLM context window: {cfg.llm_context_size} tokens",
             f"STT model: Whisper {cfg.stt_model_size}",
-            f"TTS: Piper (offline voice synthesis)",
-            f"OCR: Tesseract (image text extraction)",
+            "TTS: Piper (offline voice synthesis)",
+            "OCR: Tesseract (image text extraction)",
         ]
         return "\n".join(stats)
     except Exception as e:

--- a/edgetutor/core/mentor.py
+++ b/edgetutor/core/mentor.py
@@ -1,0 +1,192 @@
+"""
+EdgeTutor AI — AI Mentor Mode.
+
+The AI Mentor teaches students about AI systems, GPUs, CUDA, LLMs,
+quantization, and the very technology running on their Jetson device.
+It turns the device itself into a learning lab.
+"""
+
+from __future__ import annotations
+
+from edgetutor.core.logging_config import get_logger
+from edgetutor.core.jetson import get_board_profile, get_total_ram_gb, get_available_ram_gb
+
+logger = get_logger(__name__)
+
+# ── Mentor system prompt ──────────────────────────────────────────────────────
+MENTOR_SYSTEM_PROMPT = """\
+You are EdgeTutor in AI Mentor mode. You teach students about artificial \
+intelligence, machine learning, GPUs, and the technology running right on \
+this device.
+
+You are running on a real NVIDIA Jetson device. The student can ask you:
+- How GPUs work and why they matter for AI
+- What CUDA is and how parallel processing helps
+- How Large Language Models (LLMs) work
+- What quantization is and why it matters on edge devices
+- How speech recognition (Whisper) works
+- How OCR extracts text from images
+- How vector search (RAG) finds relevant information
+- What neural networks are and how they learn
+
+{age_tone}
+
+IMPORTANT RULES:
+- You are running locally on a Jetson device with no internet. \
+  Never suggest visiting websites.
+- Use the real system stats below to make explanations concrete and tangible.
+- Encourage curiosity. This is their AI lab!
+- Be accurate but accessible. Use analogies.
+- If they ask about your own architecture, explain it honestly and excitedly.
+
+CURRENT SYSTEM STATS:
+{system_stats}
+"""
+
+# ── Mentor topic library ──────────────────────────────────────────────────────
+MENTOR_TOPICS = {
+    "gpu": {
+        "title": "How GPUs Work",
+        "prompt": (
+            "Explain how a GPU (Graphics Processing Unit) works differently from "
+            "a CPU. Use analogies appropriate for the student's age. Mention that "
+            "this Jetson device has a real NVIDIA GPU with CUDA cores."
+        ),
+    },
+    "cuda": {
+        "title": "What is CUDA?",
+        "prompt": (
+            "Explain CUDA — NVIDIA's parallel computing platform. Describe how "
+            "it lets the GPU do many calculations at once, like having thousands "
+            "of tiny workers instead of a few fast ones. Reference the actual "
+            "CUDA cores on this Jetson device."
+        ),
+    },
+    "llm": {
+        "title": "How LLMs Work",
+        "prompt": (
+            "Explain how Large Language Models (LLMs) work at a high level. "
+            "Cover: training on text data, tokens, prediction of next words, "
+            "and how the model running on this device generates responses. "
+            "Mention that the student is talking to a real LLM right now!"
+        ),
+    },
+    "quantization": {
+        "title": "What is Quantization?",
+        "prompt": (
+            "Explain model quantization — why we shrink AI models to run on "
+            "small devices like Jetson. Use an analogy (e.g., compressing a "
+            "photo). Mention the actual model size and quantization level "
+            "being used on this device."
+        ),
+    },
+    "whisper": {
+        "title": "How Speech Recognition Works",
+        "prompt": (
+            "Explain how the Whisper speech-to-text model converts voice to "
+            "text. Cover: audio → spectrogram → neural network → text. "
+            "The student can test it by speaking into the microphone!"
+        ),
+    },
+    "ocr": {
+        "title": "How OCR Works",
+        "prompt": (
+            "Explain Optical Character Recognition (OCR) — how computers read "
+            "text from images. Cover: image preprocessing, character detection, "
+            "pattern matching. The student can test it by holding up a page!"
+        ),
+    },
+    "rag": {
+        "title": "How AI Search (RAG) Works",
+        "prompt": (
+            "Explain Retrieval-Augmented Generation (RAG) — how the tutor "
+            "searches curriculum packs to find relevant information before "
+            "answering. Cover: embeddings, vector similarity, and why this "
+            "makes AI answers more accurate."
+        ),
+    },
+    "neural_networks": {
+        "title": "What are Neural Networks?",
+        "prompt": (
+            "Explain neural networks at an age-appropriate level. Use the "
+            "analogy of brain neurons. Cover: layers, weights, learning from "
+            "examples, and how they can recognize patterns (images, speech, text)."
+        ),
+    },
+    "edge_ai": {
+        "title": "What is Edge AI?",
+        "prompt": (
+            "Explain Edge AI — running AI models directly on devices instead "
+            "of in the cloud. Cover: privacy (data stays local), speed (no "
+            "internet latency), and independence (works offline). This Jetson "
+            "device IS edge AI!"
+        ),
+    },
+    "this_device": {
+        "title": "About This Device",
+        "prompt": (
+            "Describe the Jetson device the student is using right now. "
+            "Use the system stats to explain what each component does: "
+            "GPU, RAM, CUDA cores. Explain how all the AI modules work "
+            "together: voice → text → AI brain → voice response."
+        ),
+    },
+}
+
+
+def get_system_stats_text() -> str:
+    """Generate a human-readable summary of current system stats."""
+    try:
+        profile = get_board_profile()
+        total_ram = get_total_ram_gb()
+        avail_ram = get_available_ram_gb()
+
+        from edgetutor.core.settings import get_settings
+        cfg = get_settings()
+
+        stats = [
+            f"Device: {profile.name}",
+            f"GPU: {profile.gpu_name}",
+            f"CUDA Cores: {profile.cuda_cores}",
+            f"RAM: {total_ram:.1f} GB total, {avail_ram:.1f} GB available",
+            f"Memory type: Unified (shared between CPU and GPU)",
+            f"LLM model: {cfg.llm_model_path}",
+            f"LLM GPU layers: {cfg.llm_n_gpu_layers}",
+            f"LLM context window: {cfg.llm_context_size} tokens",
+            f"STT model: Whisper {cfg.stt_model_size}",
+            f"TTS: Piper (offline voice synthesis)",
+            f"OCR: Tesseract (image text extraction)",
+        ]
+        return "\n".join(stats)
+    except Exception as e:
+        logger.warning("Could not get system stats: %s", e)
+        return "System stats unavailable."
+
+
+def build_mentor_prompt(age: str = "10") -> str:
+    """Build the AI Mentor system prompt with current system stats."""
+    from edgetutor.core.prompts import AGE_TONES
+
+    age_tone = AGE_TONES.get(age, AGE_TONES["10"])
+    stats = get_system_stats_text()
+
+    return MENTOR_SYSTEM_PROMPT.format(
+        age_tone=age_tone,
+        system_stats=stats,
+    ).strip()
+
+
+def get_mentor_topic_list() -> list[dict]:
+    """Return the list of mentor topics for the UI."""
+    return [
+        {"key": key, "title": info["title"]}
+        for key, info in MENTOR_TOPICS.items()
+    ]
+
+
+def get_mentor_topic_prompt(topic_key: str) -> str:
+    """Get the prompt for a specific mentor topic."""
+    topic = MENTOR_TOPICS.get(topic_key)
+    if topic:
+        return topic["prompt"]
+    return f"The student wants to learn about: {topic_key}"

--- a/edgetutor/core/rag.py
+++ b/edgetutor/core/rag.py
@@ -69,7 +69,7 @@ class RAGStore:
             import faiss
 
             self.index = faiss.read_index(str(index_file))
-            with open(meta_file, "r", encoding="utf-8") as f:
+            with open(meta_file, encoding="utf-8") as f:
                 self.chunks = json.load(f)
 
             logger.info(
@@ -147,8 +147,6 @@ class RAGStore:
         logger.info("Chunked %d documents into %d chunks", len(documents), len(self.chunks))
 
         # Embed
-        import numpy as np
-
         texts = [c["text"] for c in self.chunks]
         t0 = time.time()
         embeddings = self.embedder.encode(texts, show_progress_bar=True, convert_to_numpy=True)
@@ -188,7 +186,6 @@ class RAGStore:
         cfg = get_settings()
         k = top_k or cfg.rag_top_k
 
-        import numpy as np
         import faiss
 
         query_vec = self.embedder.encode([text], convert_to_numpy=True)
@@ -197,7 +194,7 @@ class RAGStore:
         scores, indices = self.index.search(query_vec, min(k, self.index.ntotal))
 
         results = []
-        for score, idx in zip(scores[0], indices[0]):
+        for score, idx in zip(scores[0], indices[0], strict=False):
             if idx < 0 or idx >= len(self.chunks):
                 continue
             chunk = self.chunks[idx]

--- a/edgetutor/core/rag.py
+++ b/edgetutor/core/rag.py
@@ -198,11 +198,13 @@ class RAGStore:
             if idx < 0 or idx >= len(self.chunks):
                 continue
             chunk = self.chunks[idx]
-            results.append({
-                "text": chunk["text"],
-                "source": chunk["source"],
-                "score": float(score),
-            })
+            results.append(
+                {
+                    "text": chunk["text"],
+                    "source": chunk["source"],
+                    "score": float(score),
+                }
+            )
 
         return results
 

--- a/edgetutor/core/rag.py
+++ b/edgetutor/core/rag.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from typing import Optional
 
 from edgetutor.core.logging_config import get_logger
 from edgetutor.core.settings import get_settings
@@ -85,7 +84,7 @@ class RAGStore:
             logger.error("Failed to load FAISS index: %s", e)
             return False
 
-    def ingest(self, content_dir: Optional[Path] = None) -> int:
+    def ingest(self, content_dir: Path | None = None) -> int:
         """
         Ingest documents from content directory into FAISS index.
 
@@ -177,7 +176,7 @@ class RAGStore:
         logger.info("FAISS index saved to %s (%d vectors)", index_dir, self.index.ntotal)
         return len(self.chunks)
 
-    def query(self, text: str, top_k: Optional[int] = None) -> list[dict]:
+    def query(self, text: str, top_k: int | None = None) -> list[dict]:
         """
         Retrieve the most relevant chunks for a query.
 

--- a/edgetutor/core/safety.py
+++ b/edgetutor/core/safety.py
@@ -20,8 +20,14 @@ _BLOCKED_INPUT_PATTERNS: list[tuple[re.Pattern, str]] = []
 
 _BLOCKED_KEYWORDS = [
     # Violence / weapons
-    (r"\b(how\s+to\s+)?(make|build|create)\s+(a\s+)?(bomb|weapon|gun|explosive|poison)\b", "weapons"),
-    (r"\b(kill|murder|assassinate|shoot|stab)\s+(someone|a\s+person|people|him|her|them)\b", "violence"),
+    (
+        r"\b(how\s+to\s+)?(make|build|create)\s+(a\s+)?(bomb|weapon|gun|explosive|poison)\b",
+        "weapons",
+    ),
+    (
+        r"\b(kill|murder|assassinate|shoot|stab)\s+(someone|a\s+person|people|him|her|them)\b",
+        "violence",
+    ),
     # Self-harm
     (r"\b(how\s+to\s+)?(commit\s+)?suicide\b", "self-harm"),
     (r"\b(cut|harm|hurt)\s+(myself|yourself|themselves)\b", "self-harm"),
@@ -36,9 +42,7 @@ _BLOCKED_KEYWORDS = [
 ]
 
 for pattern_str, category in _BLOCKED_KEYWORDS:
-    _BLOCKED_INPUT_PATTERNS.append(
-        (re.compile(pattern_str, re.IGNORECASE), category)
-    )
+    _BLOCKED_INPUT_PATTERNS.append((re.compile(pattern_str, re.IGNORECASE), category))
 
 # ── Calm redirect message ─────────────────────────────────────────────────────
 REDIRECT_MESSAGE = (

--- a/edgetutor/core/safety.py
+++ b/edgetutor/core/safety.py
@@ -4,6 +4,9 @@ EdgeTutor AI — Kid-safe guardrail layer.
 Lightweight keyword + pattern filter that runs BEFORE the LLM sees user input
 and AFTER the LLM produces output. This is a practical, low-overhead approach;
 it is not meant to be bullet-proof but to catch common unsafe queries.
+
+Includes leetspeak / variant spelling normalization so simple evasion
+attempts like "b0mb" or "p0rn" are also caught.
 """
 
 from __future__ import annotations
@@ -13,6 +16,29 @@ import re
 from edgetutor.core.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+# ── Leetspeak / variant normalization ─────────────────────────────────────────
+_LEET_MAP: dict[str, str] = {
+    "0": "o",
+    "1": "i",
+    "3": "e",
+    "4": "a",
+    "5": "s",
+    "7": "t",
+    "@": "a",
+    "$": "s",
+    "!": "i",
+    "+": "t",
+}
+
+
+def _normalize_leet(text: str) -> str:
+    """Normalize common leetspeak substitutions back to plain English."""
+    result = []
+    for ch in text:
+        result.append(_LEET_MAP.get(ch, ch))
+    return "".join(result)
+
 
 # ── Blocked input patterns (user queries) ─────────────────────────────────────
 # Each tuple: (compiled regex, category label)
@@ -64,6 +90,9 @@ def check_input_safety(text: str) -> tuple[bool, str]:
     """
     Check if user input is safe.
 
+    Applies leetspeak normalization before pattern matching so that
+    common evasion attempts like "b0mb" or "p0rn" are still caught.
+
     Returns:
         (is_safe, category_or_empty): True if safe, False + category if blocked.
     """
@@ -71,10 +100,14 @@ def check_input_safety(text: str) -> tuple[bool, str]:
         return True, ""
 
     cleaned = text.strip()
-    for pattern, category in _BLOCKED_INPUT_PATTERNS:
-        if pattern.search(cleaned):
-            logger.warning("Blocked input — category=%s, length=%d", category, len(cleaned))
-            return False, category
+
+    # Check both original text and leetspeak-normalized version
+    variants = [cleaned, _normalize_leet(cleaned)]
+    for variant in variants:
+        for pattern, category in _BLOCKED_INPUT_PATTERNS:
+            if pattern.search(variant):
+                logger.warning("Blocked input — category=%s, length=%d", category, len(cleaned))
+                return False, category
 
     return True, ""
 

--- a/edgetutor/core/settings.py
+++ b/edgetutor/core/settings.py
@@ -39,14 +39,14 @@ class Settings(BaseSettings):
 
     # ── Server ────────────────────────────────────────────────────────────────
     host: str = Field(default="0.0.0.0", alias="EDGETUTOR_HOST")
-    port: int = Field(default=7860, alias="EDGETUTOR_PORT")
+    port: int = Field(default=7860, alias="EDGETUTOR_PORT", ge=1, le=65535)
 
     # ── LLM ───────────────────────────────────────────────────────────────────
     llm_model_path: str = Field(default="models/default.gguf", alias="LLM_MODEL_PATH")
-    llm_n_gpu_layers: int = Field(default=20, alias="LLM_N_GPU_LAYERS")
-    llm_context_size: int = Field(default=2048, alias="LLM_CONTEXT_SIZE")
-    llm_max_tokens: int = Field(default=512, alias="LLM_MAX_TOKENS")
-    llm_temperature: float = Field(default=0.7, alias="LLM_TEMPERATURE")
+    llm_n_gpu_layers: int = Field(default=20, alias="LLM_N_GPU_LAYERS", ge=-1, le=200)
+    llm_context_size: int = Field(default=2048, alias="LLM_CONTEXT_SIZE", ge=128, le=131072)
+    llm_max_tokens: int = Field(default=512, alias="LLM_MAX_TOKENS", ge=1, le=32768)
+    llm_temperature: float = Field(default=0.7, alias="LLM_TEMPERATURE", ge=0.0, le=2.0)
 
     # ── STT ───────────────────────────────────────────────────────────────────
     stt_model_size: str = Field(default="small", alias="STT_MODEL_SIZE")
@@ -58,7 +58,7 @@ class Settings(BaseSettings):
     # ── TTS ───────────────────────────────────────────────────────────────────
     tts_voice_model: str = Field(default="voices/en_US-lessac-medium.onnx", alias="TTS_VOICE_MODEL")
     tts_enabled: bool = Field(default=True, alias="TTS_ENABLED")
-    tts_rate: float = Field(default=1.0, alias="TTS_RATE")
+    tts_rate: float = Field(default=1.0, alias="TTS_RATE", ge=0.1, le=5.0)
 
     # ── Vision / OCR ──────────────────────────────────────────────────────────
     ocr_engine: str = Field(default="tesseract", alias="OCR_ENGINE")
@@ -71,8 +71,8 @@ class Settings(BaseSettings):
     rag_embedding_model: str = Field(
         default="sentence-transformers/all-MiniLM-L6-v2", alias="RAG_EMBEDDING_MODEL"
     )
-    rag_top_k: int = Field(default=3, alias="RAG_TOP_K")
-    rag_chunk_size: int = Field(default=500, alias="RAG_CHUNK_SIZE")
+    rag_top_k: int = Field(default=3, alias="RAG_TOP_K", ge=1, le=100)
+    rag_chunk_size: int = Field(default=500, alias="RAG_CHUNK_SIZE", ge=50, le=10000)
 
     # ── Safety ────────────────────────────────────────────────────────────────
     safety_enabled: bool = Field(default=True, alias="SAFETY_ENABLED")

--- a/edgetutor/core/settings.py
+++ b/edgetutor/core/settings.py
@@ -74,6 +74,11 @@ class Settings(BaseSettings):
     rag_top_k: int = Field(default=3, alias="RAG_TOP_K", ge=1, le=100)
     rag_chunk_size: int = Field(default=500, alias="RAG_CHUNK_SIZE", ge=50, le=10000)
 
+    # ── Conversation ─────────────────────────────────────────────────────────
+    conversation_history_limit: int = Field(
+        default=20, alias="CONVERSATION_HISTORY_LIMIT", ge=1, le=200
+    )
+
     # ── Safety ────────────────────────────────────────────────────────────────
     safety_enabled: bool = Field(default=True, alias="SAFETY_ENABLED")
 

--- a/edgetutor/core/settings.py
+++ b/edgetutor/core/settings.py
@@ -7,10 +7,8 @@ defaults so the app works out-of-the-box on a fresh Jetson.
 
 from __future__ import annotations
 
-import os
 from enum import Enum
 from pathlib import Path
-from typing import Optional
 
 from pydantic import Field
 from pydantic_settings import BaseSettings
@@ -132,3 +130,9 @@ def get_settings() -> Settings:
     if not hasattr(get_settings, "_instance"):
         get_settings._instance = Settings()
     return get_settings._instance
+
+
+def reset_settings() -> None:
+    """Reset the cached settings singleton (for testing)."""
+    if hasattr(get_settings, "_instance"):
+        del get_settings._instance

--- a/edgetutor/core/settings.py
+++ b/edgetutor/core/settings.py
@@ -56,9 +56,7 @@ class Settings(BaseSettings):
     stt_enabled: bool = Field(default=True, alias="STT_ENABLED")
 
     # ── TTS ───────────────────────────────────────────────────────────────────
-    tts_voice_model: str = Field(
-        default="voices/en_US-lessac-medium.onnx", alias="TTS_VOICE_MODEL"
-    )
+    tts_voice_model: str = Field(default="voices/en_US-lessac-medium.onnx", alias="TTS_VOICE_MODEL")
     tts_enabled: bool = Field(default=True, alias="TTS_ENABLED")
     tts_rate: float = Field(default=1.0, alias="TTS_RATE")
 

--- a/edgetutor/tests/conftest.py
+++ b/edgetutor/tests/conftest.py
@@ -4,17 +4,26 @@ Pytest configuration and shared fixtures for EdgeTutor tests.
 These fixtures ensure tests can run in CI without hardware dependencies.
 """
 
-import os
 import pytest
+
+from edgetutor.core.settings import reset_settings
 
 
 @pytest.fixture(autouse=True)
 def disable_hardware_for_tests(monkeypatch):
     """Disable hardware-dependent features during testing."""
+    # Reset the cached settings singleton so each test gets fresh settings
+    reset_settings()
+
     monkeypatch.setenv("STT_ENABLED", "false")
     monkeypatch.setenv("TTS_ENABLED", "false")
     monkeypatch.setenv("CAMERA_ENABLED", "false")
     monkeypatch.setenv("LLM_MODEL_PATH", "models/nonexistent.gguf")
+
+    yield
+
+    # Clean up after each test
+    reset_settings()
 
 
 @pytest.fixture

--- a/edgetutor/tests/test_conversations.py
+++ b/edgetutor/tests/test_conversations.py
@@ -1,0 +1,106 @@
+"""Tests for edgetutor.core.conversations — conversation persistence."""
+
+import json
+
+
+class TestConversationStore:
+    """Test ConversationStore save/load/list/delete."""
+
+    def test_save_and_load(self, tmp_path):
+        """Should save and reload a conversation."""
+        from edgetutor.core.conversations import ConversationStore
+
+        store = ConversationStore(storage_dir=tmp_path)
+        history = [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "2 + 2 = 4!"},
+        ]
+
+        store.save("session-1", history)
+        loaded = store.load("session-1")
+
+        assert len(loaded) == 2
+        assert loaded[0]["role"] == "user"
+        assert loaded[1]["content"] == "2 + 2 = 4!"
+
+    def test_load_nonexistent(self, tmp_path):
+        """Loading a missing session should return empty list."""
+        from edgetutor.core.conversations import ConversationStore
+
+        store = ConversationStore(storage_dir=tmp_path)
+        assert store.load("does-not-exist") == []
+
+    def test_load_corrupt_file(self, tmp_path):
+        """Loading a corrupt file should return empty list, not crash."""
+        from edgetutor.core.conversations import ConversationStore
+
+        store = ConversationStore(storage_dir=tmp_path)
+        (tmp_path / "bad.json").write_text("not valid json {{{")
+        assert store.load("bad") == []
+
+    def test_list_sessions(self, tmp_path):
+        """Should list all sessions sorted by most recent."""
+        from edgetutor.core.conversations import ConversationStore
+
+        store = ConversationStore(storage_dir=tmp_path)
+        store.save("older", [{"role": "user", "content": "hi"}])
+        store.save(
+            "newer",
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hey"},
+            ],
+        )
+
+        sessions = store.list_sessions()
+        assert len(sessions) == 2
+        # Most recent first
+        assert sessions[0]["session_id"] == "newer"
+        assert sessions[0]["message_count"] == 2
+        assert sessions[1]["session_id"] == "older"
+        assert sessions[1]["message_count"] == 1
+
+    def test_delete_session(self, tmp_path):
+        """Should delete a session file."""
+        from edgetutor.core.conversations import ConversationStore
+
+        store = ConversationStore(storage_dir=tmp_path)
+        store.save("to-delete", [{"role": "user", "content": "bye"}])
+
+        assert store.delete("to-delete") is True
+        assert store.load("to-delete") == []
+
+    def test_delete_nonexistent(self, tmp_path):
+        """Deleting a missing session should return False."""
+        from edgetutor.core.conversations import ConversationStore
+
+        store = ConversationStore(storage_dir=tmp_path)
+        assert store.delete("nope") is False
+
+    def test_storage_dir_created(self, tmp_path):
+        """Constructor should create the storage directory."""
+        from edgetutor.core.conversations import ConversationStore
+
+        new_dir = tmp_path / "nested" / "convos"
+        store = ConversationStore(storage_dir=new_dir)
+        assert store.storage_dir.exists()
+
+    def test_save_creates_valid_json(self, tmp_path):
+        """Saved file should be valid JSON with expected fields."""
+        from edgetutor.core.conversations import ConversationStore
+
+        store = ConversationStore(storage_dir=tmp_path)
+        store.save("test", [{"role": "user", "content": "hello"}])
+
+        data = json.loads((tmp_path / "test.json").read_text(encoding="utf-8"))
+        assert data["session_id"] == "test"
+        assert "updated_at" in data
+        assert isinstance(data["messages"], list)
+        assert len(data["messages"]) == 1
+
+    def test_singleton(self):
+        """get_conversation_store() should return a ConversationStore."""
+        from edgetutor.core.conversations import ConversationStore, get_conversation_store
+
+        store = get_conversation_store()
+        assert isinstance(store, ConversationStore)

--- a/edgetutor/tests/test_jetson.py
+++ b/edgetutor/tests/test_jetson.py
@@ -53,7 +53,7 @@ class TestModelTiers:
         """Model tiers should be ordered from largest to smallest."""
         for i in range(len(MODEL_TIERS) - 1):
             assert MODEL_TIERS[i]["size_gb"] >= MODEL_TIERS[i + 1]["size_gb"], (
-                f"Model tiers not ordered: {MODEL_TIERS[i]['name']} > {MODEL_TIERS[i+1]['name']}"
+                f"Model tiers not ordered: {MODEL_TIERS[i]['name']} > {MODEL_TIERS[i + 1]['name']}"
             )
 
     def test_all_tiers_have_required_fields(self):

--- a/edgetutor/tests/test_jetson.py
+++ b/edgetutor/tests/test_jetson.py
@@ -1,7 +1,5 @@
 """Tests for edgetutor.core.jetson — hardware detection and model recommendation."""
 
-import pytest
-
 from edgetutor.core.jetson import (
     JETSON_PROFILES,
     MODEL_TIERS,

--- a/edgetutor/tests/test_llm.py
+++ b/edgetutor/tests/test_llm.py
@@ -1,0 +1,251 @@
+"""Tests for edgetutor.core.llm — LLM backend (mock-based, no model required)."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestLLMBackendInit:
+    """Test LLMBackend initialization and state."""
+
+    def test_default_state(self):
+        """LLM backend should start unloaded."""
+        from edgetutor.core.llm import LLMBackend
+
+        llm = LLMBackend()
+        assert llm.is_loaded is False
+        assert llm.model is None
+
+    def test_singleton_returns_instance(self):
+        """get_llm() should return an LLMBackend."""
+        from edgetutor.core.llm import LLMBackend, get_llm
+
+        llm = get_llm()
+        assert isinstance(llm, LLMBackend)
+
+
+class TestLLMLoad:
+    """Test model loading (mocked)."""
+
+    def test_load_missing_model_file(self):
+        """Loading a model that doesn't exist should return False."""
+        from edgetutor.core.llm import LLMBackend
+
+        llm = LLMBackend()
+        result = llm.load()
+        assert result is False
+        assert llm.is_loaded is False
+
+    def test_load_missing_package(self, tmp_path, monkeypatch):
+        """Should return False if llama-cpp-python is not installed."""
+        from edgetutor.core.llm import LLMBackend
+        from edgetutor.core.settings import get_settings
+
+        # Create a fake model file
+        model_file = tmp_path / "fake.gguf"
+        model_file.write_text("fake")
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "llm_model_path", str(model_file))
+
+        llm = LLMBackend()
+
+        # Patch the resolved path to return our temp file
+        with (
+            patch.object(
+                type(cfg),
+                "llm_model_resolved",
+                new_callable=lambda: property(lambda s: model_file),
+            ),
+            patch.dict("sys.modules", {"llama_cpp": None}),
+        ):
+            result = llm.load()
+
+        assert result is False
+
+
+class TestLLMGenerate:
+    """Test generation (mocked model)."""
+
+    def test_generate_when_not_loaded(self):
+        """Generating without a loaded model should return error message."""
+        from edgetutor.core.llm import LLMBackend
+
+        llm = LLMBackend()
+        result = llm.generate("What is 2+2?")
+        assert "not loaded" in result.lower()
+
+    def test_generate_with_unsafe_input(self, monkeypatch):
+        """Unsafe input should be blocked before reaching the model."""
+        from edgetutor.core.llm import LLMBackend
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", True)
+
+        llm = LLMBackend()
+        llm.model = MagicMock()  # Pretend model is loaded
+
+        result = llm.generate("how to make a bomb")
+        assert "learn" in result.lower()  # Should get redirect message
+        # Model should NOT have been called
+        llm.model.create_chat_completion.assert_not_called()
+
+    def test_generate_with_safe_input_calls_model(self, monkeypatch):
+        """Safe input should reach the model and return its response."""
+        from edgetutor.core.llm import LLMBackend
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", True)
+
+        llm = LLMBackend()
+        mock_model = MagicMock()
+        mock_model.create_chat_completion.return_value = {
+            "choices": [{"message": {"content": "2 + 2 equals 4!"}}],
+            "usage": {"total_tokens": 42},
+        }
+        llm.model = mock_model
+
+        result = llm.generate("What is 2+2?")
+        assert "4" in result
+        mock_model.create_chat_completion.assert_called_once()
+
+    def test_generate_scrubs_unsafe_output(self, monkeypatch):
+        """Unsafe model output should be replaced with redirect message."""
+        from edgetutor.core.llm import LLMBackend
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", True)
+
+        llm = LLMBackend()
+        mock_model = MagicMock()
+        mock_model.create_chat_completion.return_value = {
+            "choices": [{"message": {"content": "Here is how to harm someone: step 1..."}}],
+            "usage": {"total_tokens": 50},
+        }
+        llm.model = mock_model
+
+        result = llm.generate("Tell me a story")
+        assert "learn" in result.lower()  # Should be redirect message
+
+    def test_generate_with_safety_disabled(self, monkeypatch):
+        """With safety disabled, unsafe input should pass through."""
+        from edgetutor.core.llm import LLMBackend
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", False)
+
+        llm = LLMBackend()
+        mock_model = MagicMock()
+        mock_model.create_chat_completion.return_value = {
+            "choices": [{"message": {"content": "response text"}}],
+            "usage": {"total_tokens": 10},
+        }
+        llm.model = mock_model
+
+        result = llm.generate("any input")
+        assert result == "response text"
+
+    def test_generate_handles_exception(self, monkeypatch):
+        """Model exceptions should return a friendly error."""
+        from edgetutor.core.llm import LLMBackend
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", False)
+
+        llm = LLMBackend()
+        mock_model = MagicMock()
+        mock_model.create_chat_completion.side_effect = RuntimeError("GPU OOM")
+        llm.model = mock_model
+
+        result = llm.generate("What is math?")
+        assert "try again" in result.lower()
+
+
+class TestLLMStream:
+    """Test streaming generation."""
+
+    def test_stream_when_not_loaded(self):
+        """Streaming without a loaded model should yield error message."""
+        from edgetutor.core.llm import LLMBackend
+
+        llm = LLMBackend()
+        tokens = list(llm.generate_stream("hello"))
+        assert len(tokens) == 1
+        assert "not loaded" in tokens[0].lower()
+
+    def test_stream_blocks_unsafe_input(self, monkeypatch):
+        """Unsafe input should yield redirect message without calling model."""
+        from edgetutor.core.llm import LLMBackend
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", True)
+
+        llm = LLMBackend()
+        llm.model = MagicMock()
+
+        tokens = list(llm.generate_stream("how to make a bomb"))
+        assert len(tokens) == 1
+        assert "learn" in tokens[0].lower()
+        llm.model.create_chat_completion.assert_not_called()
+
+    def test_stream_yields_tokens(self, monkeypatch):
+        """Safe input should yield tokens from the model."""
+        from edgetutor.core.llm import LLMBackend
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", False)
+
+        llm = LLMBackend()
+        mock_model = MagicMock()
+        mock_model.create_chat_completion.return_value = iter(
+            [
+                {"choices": [{"delta": {"content": "Hello"}}]},
+                {"choices": [{"delta": {"content": " world"}}]},
+                {"choices": [{"delta": {"content": "!"}}]},
+            ]
+        )
+        llm.model = mock_model
+
+        tokens = list(llm.generate_stream("say hello"))
+        assert tokens == ["Hello", " world", "!"]
+
+
+class TestLLMConversationHistory:
+    """Test conversation history handling."""
+
+    def test_generate_passes_history_to_model(self, monkeypatch):
+        """Conversation history should be included in messages sent to model."""
+        from edgetutor.core.llm import LLMBackend
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", False)
+
+        llm = LLMBackend()
+        mock_model = MagicMock()
+        mock_model.create_chat_completion.return_value = {
+            "choices": [{"message": {"content": "The answer is 42."}}],
+            "usage": {"total_tokens": 20},
+        }
+        llm.model = mock_model
+
+        history = [
+            {"role": "user", "content": "What is the meaning of life?"},
+            {"role": "assistant", "content": "That's a philosophical question!"},
+        ]
+        llm.generate("Tell me more", conversation_history=history)
+
+        # Extract the messages that were passed to the model
+        call_args = mock_model.create_chat_completion.call_args
+        messages = call_args[1]["messages"] if "messages" in call_args[1] else call_args[0][0]
+
+        # Should have: system + 2 history + 1 user = 4 messages
+        assert len(messages) == 4
+        assert messages[0]["role"] == "system"
+        assert messages[1]["content"] == "What is the meaning of life?"
+        assert messages[3]["content"] == "Tell me more"

--- a/edgetutor/tests/test_logging.py
+++ b/edgetutor/tests/test_logging.py
@@ -1,0 +1,47 @@
+"""Tests for edgetutor.core.logging_config — logging setup."""
+
+import logging
+
+
+class TestLoggingConfig:
+    """Test logging configuration."""
+
+    def test_get_logger_returns_named_logger(self):
+        """get_logger() should return a logger with the given name."""
+        from edgetutor.core.logging_config import get_logger
+
+        logger = get_logger("test.module")
+        assert isinstance(logger, logging.Logger)
+        assert logger.name == "test.module"
+
+    def test_get_logger_different_names(self):
+        """Different names should return different loggers."""
+        from edgetutor.core.logging_config import get_logger
+
+        logger_a = get_logger("module.a")
+        logger_b = get_logger("module.b")
+        assert logger_a is not logger_b
+        assert logger_a.name != logger_b.name
+
+    def test_setup_logging_is_idempotent(self):
+        """Calling setup_logging() multiple times should not duplicate handlers."""
+        from edgetutor.core.logging_config import setup_logging
+
+        # setup_logging is guarded by the _CONFIGURED flag
+        # Calling it twice should not add extra handlers to the root logger
+        setup_logging()
+        root = logging.getLogger()
+        handler_count_before = len(root.handlers)
+
+        setup_logging()
+        handler_count_after = len(root.handlers)
+
+        assert handler_count_after == handler_count_before
+
+    def test_root_logger_has_handlers(self):
+        """After setup, root logger should have console + file handlers."""
+        from edgetutor.core.logging_config import setup_logging
+
+        setup_logging()
+        root = logging.getLogger()
+        assert len(root.handlers) >= 1  # At minimum the console handler

--- a/edgetutor/tests/test_main.py
+++ b/edgetutor/tests/test_main.py
@@ -1,0 +1,63 @@
+"""Tests for edgetutor.__main__ — application entry point."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestMain:
+    """Test the main() entry point."""
+
+    def test_main_calls_launch_ui(self):
+        """main() should call launch_ui()."""
+        mock_ui_module = MagicMock()
+        mock_ui_module.launch_ui = MagicMock()
+
+        with patch.dict(sys.modules, {"edgetutor.app.ui": mock_ui_module, "gradio": MagicMock()}):
+            from edgetutor.__main__ import main
+
+            main()
+            mock_ui_module.launch_ui.assert_called_once()
+
+    def test_main_handles_keyboard_interrupt(self):
+        """main() should exit cleanly on KeyboardInterrupt."""
+        mock_ui_module = MagicMock()
+        mock_ui_module.launch_ui = MagicMock(side_effect=KeyboardInterrupt)
+
+        with (
+            patch.dict(sys.modules, {"edgetutor.app.ui": mock_ui_module, "gradio": MagicMock()}),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            if "edgetutor.__main__" in sys.modules:
+                importlib.reload(sys.modules["edgetutor.__main__"])
+            from edgetutor.__main__ import main
+
+            main()
+
+        assert exc_info.value.code == 0
+
+    def test_main_handles_runtime_error(self):
+        """main() should exit with code 1 on unexpected error."""
+        mock_ui_module = MagicMock()
+        mock_ui_module.launch_ui = MagicMock(side_effect=RuntimeError("boom"))
+
+        with (
+            patch.dict(sys.modules, {"edgetutor.app.ui": mock_ui_module, "gradio": MagicMock()}),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            if "edgetutor.__main__" in sys.modules:
+                importlib.reload(sys.modules["edgetutor.__main__"])
+            from edgetutor.__main__ import main
+
+            main()
+
+        assert exc_info.value.code == 1
+
+    def test_version_is_available(self):
+        """__version__ should be importable from edgetutor."""
+        from edgetutor import __version__
+
+        assert isinstance(__version__, str)
+        assert len(__version__) > 0

--- a/edgetutor/tests/test_mentor.py
+++ b/edgetutor/tests/test_mentor.py
@@ -1,7 +1,5 @@
 """Tests for edgetutor.core.mentor — AI Mentor mode."""
 
-import pytest
-
 from edgetutor.core.mentor import (
     MENTOR_TOPICS,
     build_mentor_prompt,

--- a/edgetutor/tests/test_mentor.py
+++ b/edgetutor/tests/test_mentor.py
@@ -1,0 +1,89 @@
+"""Tests for edgetutor.core.mentor — AI Mentor mode."""
+
+import pytest
+
+from edgetutor.core.mentor import (
+    MENTOR_TOPICS,
+    build_mentor_prompt,
+    get_mentor_topic_list,
+    get_mentor_topic_prompt,
+    get_system_stats_text,
+)
+
+
+class TestMentorPrompt:
+    """Test mentor system prompt building."""
+
+    def test_prompt_contains_ai_mentor(self):
+        """Mentor prompt should identify the AI Mentor role."""
+        prompt = build_mentor_prompt()
+        assert "Mentor" in prompt or "mentor" in prompt
+
+    def test_prompt_includes_system_stats(self):
+        """Mentor prompt should include system stats."""
+        prompt = build_mentor_prompt()
+        # Should have some system stat info (even if "unavailable")
+        assert "Device" in prompt or "unavailable" in prompt.lower() or "Board" in prompt
+
+    def test_prompt_respects_age(self):
+        """Mentor prompt should adapt to age."""
+        prompt_7 = build_mentor_prompt(age="7")
+        prompt_16 = build_mentor_prompt(age="16")
+        assert "7-year-old" in prompt_7 or "simple" in prompt_7.lower()
+        assert "16-year-old" in prompt_16 or "advanced" in prompt_16.lower()
+
+
+class TestMentorTopics:
+    """Test mentor topic library."""
+
+    def test_topics_exist(self):
+        """Should have at least 8 topics."""
+        assert len(MENTOR_TOPICS) >= 8
+
+    def test_key_topics_present(self):
+        """Key topics should be present."""
+        expected = ["gpu", "cuda", "llm", "quantization", "this_device"]
+        for key in expected:
+            assert key in MENTOR_TOPICS, f"Missing topic: {key}"
+
+    def test_all_topics_have_title_and_prompt(self):
+        """Every topic should have title and prompt."""
+        for key, topic in MENTOR_TOPICS.items():
+            assert "title" in topic, f"Topic {key} missing title"
+            assert "prompt" in topic, f"Topic {key} missing prompt"
+            assert len(topic["title"]) > 0
+            assert len(topic["prompt"]) > 10
+
+    def test_topic_list(self):
+        """get_mentor_topic_list should return formatted list."""
+        topics = get_mentor_topic_list()
+        assert len(topics) == len(MENTOR_TOPICS)
+        for item in topics:
+            assert "key" in item
+            assert "title" in item
+
+    def test_get_topic_prompt(self):
+        """Should return the prompt for a known topic."""
+        prompt = get_mentor_topic_prompt("gpu")
+        assert "GPU" in prompt
+
+    def test_get_unknown_topic_prompt(self):
+        """Unknown topic should return a generic prompt."""
+        prompt = get_mentor_topic_prompt("quantum_computing")
+        assert "quantum_computing" in prompt
+
+
+class TestSystemStats:
+    """Test system stats text generation."""
+
+    def test_returns_string(self):
+        """Should return a non-empty string."""
+        stats = get_system_stats_text()
+        assert isinstance(stats, str)
+        assert len(stats) > 0
+
+    def test_includes_device_info(self):
+        """Stats should mention device info."""
+        stats = get_system_stats_text()
+        # On non-Jetson systems, should still have some info
+        assert "Device" in stats or "unavailable" in stats.lower()

--- a/edgetutor/tests/test_ocr.py
+++ b/edgetutor/tests/test_ocr.py
@@ -1,7 +1,5 @@
 """Tests for edgetutor.vision.ocr — OCR pipeline and math detection."""
 
-import pytest
-
 
 class TestMathDetection:
     """Test the math detection heuristics (does not require Tesseract)."""

--- a/edgetutor/tests/test_orchestrator.py
+++ b/edgetutor/tests/test_orchestrator.py
@@ -1,7 +1,5 @@
 """Tests for edgetutor.app.orchestrator — tutor orchestrator."""
 
-import pytest
-
 from edgetutor.app.orchestrator import TutorOrchestrator, TutorRequest, TutorResponse
 
 

--- a/edgetutor/tests/test_orchestrator.py
+++ b/edgetutor/tests/test_orchestrator.py
@@ -58,7 +58,10 @@ class TestOrchestratorInit:
         """Suggestions with OCR context should offer follow-ups."""
         orch = TutorOrchestrator()
         suggestions = orch._generate_suggestions("", "some ocr text", "math")
-        assert any("scan" in s.lower() or "explain" in s.lower() or "check" in s.lower() for s in suggestions)
+        assert any(
+            "scan" in s.lower() or "explain" in s.lower() or "check" in s.lower()
+            for s in suggestions
+        )
 
     def test_apply_settings(self):
         """_apply_settings should update runtime config."""

--- a/edgetutor/tests/test_orchestrator_integration.py
+++ b/edgetutor/tests/test_orchestrator_integration.py
@@ -1,0 +1,194 @@
+"""Integration tests for orchestrator.process() and process_stream() with mocked modules."""
+
+from unittest.mock import MagicMock
+
+from edgetutor.app.orchestrator import TutorOrchestrator, TutorRequest
+
+
+def _make_orchestrator_with_llm(generate_return="The answer is 4."):
+    """Create an orchestrator with a mocked LLM that returns a known response."""
+    orch = TutorOrchestrator()
+    mock_llm = MagicMock()
+    mock_llm.is_loaded = True
+    mock_llm.generate.return_value = generate_return
+    mock_llm.generate_stream.return_value = iter(list(generate_return))
+    orch._llm = mock_llm
+    return orch
+
+
+class TestOrchestratorProcess:
+    """Test the full process() pipeline with mocked modules."""
+
+    def test_process_text_only(self):
+        """Text-only request should go through LLM and return response."""
+        orch = _make_orchestrator_with_llm("The answer is 4.")
+        request = TutorRequest(user_text="What is 2+2?")
+
+        response = orch.process(request)
+
+        assert response.text == "The answer is 4."
+        assert "total" in response.latency
+        assert response.errors == []
+        orch._llm.generate.assert_called_once()
+
+    def test_process_no_llm(self):
+        """Without LLM loaded, should return an error message."""
+        orch = TutorOrchestrator()
+        request = TutorRequest(user_text="Hello")
+
+        response = orch.process(request)
+
+        assert "not loaded" in response.text.lower() or "model" in response.text.lower()
+
+    def test_process_safety_blocks_input(self, monkeypatch):
+        """Unsafe input should be blocked before reaching LLM."""
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", True)
+
+        orch = _make_orchestrator_with_llm()
+        request = TutorRequest(user_text="how to make a bomb")
+
+        response = orch.process(request)
+
+        # Should get redirect message, LLM should NOT be called
+        assert "question" in response.text.lower() or "topic" in response.text.lower()
+        orch._llm.generate.assert_not_called()
+
+    def test_process_with_stt(self):
+        """Audio input should go through STT before LLM."""
+        import numpy as np
+
+        orch = _make_orchestrator_with_llm("Photosynthesis is...")
+
+        mock_stt = MagicMock()
+        mock_stt.is_ready = True
+        mock_stt.transcribe_numpy.return_value = {
+            "text": "What is photosynthesis?",
+            "language": "en",
+            "duration_s": 2.0,
+            "elapsed_s": 0.5,
+        }
+        orch._stt = mock_stt
+
+        audio = np.zeros(16000, dtype=np.float32)
+        request = TutorRequest(audio_array=audio, audio_sample_rate=16000)
+
+        response = orch.process(request)
+
+        mock_stt.transcribe_numpy.assert_called_once()
+        assert "stt" in response.latency
+        assert response.text == "Photosynthesis is..."
+
+    def test_process_with_ocr(self):
+        """Image input should go through OCR before LLM."""
+        orch = _make_orchestrator_with_llm("Let me explain this worksheet...")
+
+        mock_ocr = MagicMock()
+        mock_ocr.is_available = True
+        mock_ocr.extract_text.return_value = {
+            "text": "3x + 7 = 22",
+            "has_math": True,
+            "math_expressions": ["3x + 7 = 22"],
+        }
+        orch._ocr = mock_ocr
+
+        request = TutorRequest(image=MagicMock())
+
+        response = orch.process(request)
+
+        mock_ocr.extract_text.assert_called_once()
+        assert "ocr" in response.latency
+        assert response.ocr_text == "3x + 7 = 22"
+        assert response.has_math is True
+
+    def test_process_stt_error_surfaces(self):
+        """STT errors should appear in response.errors."""
+        orch = _make_orchestrator_with_llm()
+
+        mock_stt = MagicMock()
+        mock_stt.is_ready = True
+        mock_stt.transcribe_numpy.return_value = {
+            "text": "",
+            "error": "Audio too short",
+        }
+        orch._stt = mock_stt
+
+        import numpy as np
+
+        audio = np.zeros(100, dtype=np.float32)
+        request = TutorRequest(audio_array=audio)
+
+        response = orch.process(request)
+
+        assert any("STT" in e for e in response.errors)
+
+    def test_process_with_settings_override(self):
+        """Settings overrides should be applied during processing."""
+        from edgetutor.core.settings import AgeMode, get_settings
+
+        orch = _make_orchestrator_with_llm()
+        request = TutorRequest(
+            user_text="Hello",
+            settings_override={"age_mode": "7", "quiz_mode": False},
+        )
+
+        orch.process(request)
+
+        cfg = get_settings()
+        assert cfg.age_mode == AgeMode.YOUNG
+
+        # Restore
+        cfg.age_mode = AgeMode.TWEEN
+
+
+class TestOrchestratorProcessStream:
+    """Test the process_stream() pipeline with mocked modules."""
+
+    def test_stream_text_only(self):
+        """Streaming text request should yield tokens."""
+        orch = _make_orchestrator_with_llm("Hello!")
+
+        request = TutorRequest(user_text="Hi there")
+        tokens = list(orch.process_stream(request))
+
+        # Should have individual characters from "Hello!"
+        assert "".join(tokens).startswith("H")
+        assert len(tokens) >= 1
+
+    def test_stream_no_llm(self):
+        """Without LLM, should yield error message."""
+        orch = TutorOrchestrator()
+        request = TutorRequest(user_text="Hello")
+
+        tokens = list(orch.process_stream(request))
+
+        assert len(tokens) == 1
+        assert "not loaded" in tokens[0].lower()
+
+    def test_stream_safety_blocks_input(self, monkeypatch):
+        """Unsafe input should yield redirect message."""
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "safety_enabled", True)
+
+        orch = _make_orchestrator_with_llm()
+        request = TutorRequest(user_text="how to make a weapon")
+
+        tokens = list(orch.process_stream(request))
+
+        full_text = "".join(tokens)
+        assert "question" in full_text.lower() or "topic" in full_text.lower()
+        orch._llm.generate_stream.assert_not_called()
+
+    def test_stream_empty_input(self):
+        """Empty input should yield greeting."""
+        orch = _make_orchestrator_with_llm()
+        request = TutorRequest(user_text="")
+
+        tokens = list(orch.process_stream(request))
+
+        full_text = "".join(tokens)
+        assert "edgetutor" in full_text.lower() or "ask" in full_text.lower()

--- a/edgetutor/tests/test_prompts.py
+++ b/edgetutor/tests/test_prompts.py
@@ -1,7 +1,5 @@
 """Tests for edgetutor.core.prompts — prompt template builders."""
 
-import pytest
-
 from edgetutor.core.prompts import (
     AGE_TONES,
     SUBJECT_INSTRUCTIONS,

--- a/edgetutor/tests/test_rag.py
+++ b/edgetutor/tests/test_rag.py
@@ -1,0 +1,183 @@
+"""Tests for edgetutor.core.rag — RAG store (mock-based, no FAISS/embedder required)."""
+
+import contextlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class TestRAGStoreInit:
+    """Test RAGStore initialization and state."""
+
+    def test_default_state(self):
+        """RAG store should start unready with no index."""
+        from edgetutor.core.rag import RAGStore
+
+        store = RAGStore()
+        assert store.is_ready is False
+        assert store.index is None
+        assert store.chunks == []
+        assert store.embedder is None
+
+    def test_singleton_returns_instance(self):
+        """get_rag() should return a RAGStore."""
+        from edgetutor.core.rag import RAGStore, get_rag
+
+        store = get_rag()
+        assert isinstance(store, RAGStore)
+
+    def test_query_when_not_ready(self):
+        """Querying an unready store should return empty list."""
+        from edgetutor.core.rag import RAGStore
+
+        store = RAGStore()
+        results = store.query("What is photosynthesis?")
+        assert results == []
+
+    def test_query_when_no_embedder(self):
+        """Querying with no embedder should return empty list."""
+        from edgetutor.core.rag import RAGStore
+
+        store = RAGStore()
+        store._ready = True
+        store.index = MagicMock()
+        store.embedder = None
+        results = store.query("test")
+        assert results == []
+
+
+class TestRAGLoadEmbedder:
+    """Test embedder loading (mocked)."""
+
+    def test_load_embedder_missing_package(self):
+        """Should return False if sentence-transformers is not installed."""
+        from edgetutor.core.rag import RAGStore
+
+        store = RAGStore()
+        with (
+            patch.dict("sys.modules", {"sentence_transformers": None}),
+            patch(
+                "edgetutor.core.rag.RAGStore.load_embedder",
+                side_effect=ImportError("No module"),
+            ),
+            contextlib.suppress(ImportError),
+        ):
+            store.load_embedder()
+        assert store.embedder is None
+
+
+class TestRAGLoadIndex:
+    """Test index loading (mocked filesystem)."""
+
+    def test_load_index_no_files(self, tmp_path, monkeypatch):
+        """Should return False when index files don't exist."""
+        from edgetutor.core.rag import RAGStore
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        # Patch the underlying path field so the resolved property points to nonexistent dir
+        monkeypatch.setattr(cfg, "rag_index_dir", str(tmp_path / "nonexistent"))
+
+        store = RAGStore()
+        result = store.load_index()
+        assert result is False
+        assert store.is_ready is False
+
+
+class TestRAGIngest:
+    """Test document ingestion logic (mocked)."""
+
+    def test_ingest_empty_directory(self, tmp_path):
+        """Ingesting from an empty directory should return 0 chunks."""
+        from edgetutor.core.rag import RAGStore
+
+        store = RAGStore()
+        store.embedder = MagicMock()  # Pretend embedder is loaded
+        result = store.ingest(content_dir=tmp_path)
+        assert result == 0
+
+    def test_ingest_no_embedder(self, tmp_path):
+        """Ingesting without embedder should return 0."""
+        from edgetutor.core.rag import RAGStore
+
+        store = RAGStore()
+        assert store.embedder is None
+        result = store.ingest(content_dir=tmp_path)
+        assert result == 0
+
+    def test_ingest_missing_directory(self):
+        """Ingesting from nonexistent directory should return 0."""
+        from edgetutor.core.rag import RAGStore
+
+        store = RAGStore()
+        store.embedder = MagicMock()
+        result = store.ingest(content_dir=Path("/nonexistent/path"))
+        assert result == 0
+
+    def test_ingest_reads_txt_files(self, tmp_path, monkeypatch):
+        """Should read .txt files from content directory."""
+        from edgetutor.core.rag import RAGStore
+
+        # Create a sample text file
+        (tmp_path / "test.txt").write_text("The sun is a star. It gives us light and heat.")
+
+        import numpy as np
+
+        # Mock embedder and faiss
+        mock_embedder = MagicMock()
+        mock_embedder.encode.return_value = np.random.rand(1, 384).astype(np.float32)
+
+        mock_faiss = MagicMock()
+        mock_index = MagicMock()
+        mock_index.ntotal = 1
+        mock_faiss.IndexFlatIP.return_value = mock_index
+
+        store = RAGStore()
+        store.embedder = mock_embedder
+
+        with (
+            patch.dict("sys.modules", {"faiss": mock_faiss}),
+            patch("edgetutor.core.rag.get_settings") as mock_cfg,
+        ):
+            cfg = MagicMock()
+            cfg.rag_chunk_size = 500
+            cfg.rag_index_resolved = tmp_path / "index"
+            mock_cfg.return_value = cfg
+
+            result = store.ingest(content_dir=tmp_path)
+
+        assert result > 0
+        assert len(store.chunks) > 0
+        assert store.chunks[0]["source"] == "test.txt"
+
+    def test_ingest_reads_md_files(self, tmp_path, monkeypatch):
+        """Should read .md files from content directory."""
+        from edgetutor.core.rag import RAGStore
+
+        (tmp_path / "notes.md").write_text("# Chapter 1\n\nPhotosynthesis is the process...")
+
+        import numpy as np
+
+        mock_embedder = MagicMock()
+        mock_embedder.encode.return_value = np.random.rand(1, 384).astype(np.float32)
+
+        mock_faiss = MagicMock()
+        mock_index = MagicMock()
+        mock_index.ntotal = 1
+        mock_faiss.IndexFlatIP.return_value = mock_index
+
+        store = RAGStore()
+        store.embedder = mock_embedder
+
+        with (
+            patch.dict("sys.modules", {"faiss": mock_faiss}),
+            patch("edgetutor.core.rag.get_settings") as mock_cfg,
+        ):
+            cfg = MagicMock()
+            cfg.rag_chunk_size = 500
+            cfg.rag_index_resolved = tmp_path / "index"
+            mock_cfg.return_value = cfg
+
+            result = store.ingest(content_dir=tmp_path)
+
+        assert result > 0
+        assert store.chunks[0]["source"] == "notes.md"

--- a/edgetutor/tests/test_safety.py
+++ b/edgetutor/tests/test_safety.py
@@ -1,7 +1,5 @@
 """Tests for edgetutor.core.safety — kid-safe guardrail layer."""
 
-import pytest
-
 from edgetutor.core.safety import (
     REDIRECT_MESSAGE,
     check_input_safety,

--- a/edgetutor/tests/test_safety.py
+++ b/edgetutor/tests/test_safety.py
@@ -2,6 +2,7 @@
 
 from edgetutor.core.safety import (
     REDIRECT_MESSAGE,
+    _normalize_leet,
     check_input_safety,
     check_output_safety,
     get_redirect_message,
@@ -67,6 +68,51 @@ class TestInputSafety:
         """Safety checks should be case-insensitive."""
         is_safe, _ = check_input_safety("HOW TO MAKE A BOMB")
         assert not is_safe
+
+
+class TestLeetspeak:
+    """Test leetspeak normalization and evasion prevention."""
+
+    def test_normalize_basic_leet(self):
+        """Common leetspeak should be normalized to plain English."""
+        assert _normalize_leet("b0mb") == "bomb"
+        assert _normalize_leet("p0rn") == "porn"
+        assert _normalize_leet("h4ck") == "hack"
+        assert _normalize_leet("$u1c1d3") == "suicide"
+
+    def test_normalize_preserves_normal_text(self):
+        """Normal text (without leet chars) should pass through unchanged."""
+        assert _normalize_leet("hello world") == "hello world"
+        assert _normalize_leet("Help me with homework") == "Help me with homework"
+
+    def test_blocks_leetspeak_weapons(self):
+        """Leetspeak weapon queries should be blocked."""
+        is_safe, category = check_input_safety("how to make a b0mb")
+        assert not is_safe
+        assert category == "weapons"
+
+    def test_blocks_leetspeak_explicit(self):
+        """Leetspeak explicit queries should be blocked."""
+        is_safe, category = check_input_safety("show me p0rn")
+        assert not is_safe
+        assert category == "explicit"
+
+    def test_blocks_leetspeak_drugs(self):
+        """Leetspeak drug queries should be blocked."""
+        is_safe, category = check_input_safety("make m3th")
+        assert not is_safe
+        assert category == "drugs"
+
+    def test_safe_leet_numbers_not_blocked(self):
+        """Numbers in normal math context should NOT be blocked."""
+        safe_inputs = [
+            "What is 50 + 30?",
+            "I scored 100 on my test",
+            "Page 137 of the textbook",
+        ]
+        for text in safe_inputs:
+            is_safe, category = check_input_safety(text)
+            assert is_safe, f"'{text}' should be safe but was blocked ({category})"
 
 
 class TestOutputSafety:

--- a/edgetutor/tests/test_settings.py
+++ b/edgetutor/tests/test_settings.py
@@ -1,7 +1,5 @@
 """Tests for edgetutor.core.settings."""
 
-from pathlib import Path
-
 
 class TestSettings:
     """Test the Settings configuration class."""
@@ -56,7 +54,8 @@ class TestSettings:
 
         s = Settings(_env_file="nonexistent.env")
         resolved = s.resolve_path("/tmp/test.gguf")
-        assert resolved == Path("/tmp/test.gguf")
+        assert resolved.is_absolute()
+        assert resolved.name == "test.gguf"
 
     def test_env_override(self, monkeypatch):
         """Settings should pick up environment variable overrides."""

--- a/edgetutor/tests/test_settings.py
+++ b/edgetutor/tests/test_settings.py
@@ -1,9 +1,6 @@
 """Tests for edgetutor.core.settings."""
 
-import os
 from pathlib import Path
-
-import pytest
 
 
 class TestSettings:

--- a/edgetutor/tests/test_settings.py
+++ b/edgetutor/tests/test_settings.py
@@ -6,9 +6,13 @@ from pathlib import Path
 class TestSettings:
     """Test the Settings configuration class."""
 
-    def test_default_values(self):
+    def test_default_values(self, monkeypatch):
         """Settings should have sensible defaults without any .env file."""
         from edgetutor.core.settings import Settings
+
+        # Clear env vars that conftest sets, so we can test true defaults
+        for key in ("STT_ENABLED", "TTS_ENABLED", "CAMERA_ENABLED", "LLM_MODEL_PATH"):
+            monkeypatch.delenv(key, raising=False)
 
         # Create with no env file
         s = Settings(_env_file="nonexistent.env")

--- a/edgetutor/tests/test_settings_validation.py
+++ b/edgetutor/tests/test_settings_validation.py
@@ -1,0 +1,111 @@
+"""Tests for edgetutor.core.settings — field validation constraints."""
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestSettingsValidation:
+    """Test that Settings rejects out-of-range values."""
+
+    def test_port_too_high(self):
+        """Port above 65535 should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="less than or equal to 65535"):
+            Settings(_env_file="nonexistent.env", port=99999)
+
+    def test_port_too_low(self):
+        """Port below 1 should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            Settings(_env_file="nonexistent.env", port=0)
+
+    def test_temperature_too_high(self):
+        """Temperature above 2.0 should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="less than or equal to 2"):
+            Settings(_env_file="nonexistent.env", llm_temperature=5.0)
+
+    def test_temperature_negative(self):
+        """Negative temperature should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="greater than or equal to 0"):
+            Settings(_env_file="nonexistent.env", llm_temperature=-0.1)
+
+    def test_context_size_too_small(self):
+        """Context size below 128 should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="greater than or equal to 128"):
+            Settings(_env_file="nonexistent.env", llm_context_size=64)
+
+    def test_max_tokens_zero(self):
+        """Max tokens of 0 should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            Settings(_env_file="nonexistent.env", llm_max_tokens=0)
+
+    def test_rag_top_k_zero(self):
+        """RAG top_k of 0 should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            Settings(_env_file="nonexistent.env", rag_top_k=0)
+
+    def test_rag_chunk_size_too_small(self):
+        """RAG chunk size below 50 should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="greater than or equal to 50"):
+            Settings(_env_file="nonexistent.env", rag_chunk_size=10)
+
+    def test_tts_rate_too_low(self):
+        """TTS rate below 0.1 should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="greater than or equal to 0.1"):
+            Settings(_env_file="nonexistent.env", tts_rate=0.0)
+
+    def test_tts_rate_too_high(self):
+        """TTS rate above 5.0 should be rejected."""
+        from edgetutor.core.settings import Settings
+
+        with pytest.raises(ValidationError, match="less than or equal to 5"):
+            Settings(_env_file="nonexistent.env", tts_rate=10.0)
+
+    def test_valid_values_accepted(self, monkeypatch):
+        """Valid edge-case values should be accepted."""
+        for key in ("STT_ENABLED", "TTS_ENABLED", "CAMERA_ENABLED", "LLM_MODEL_PATH"):
+            monkeypatch.delenv(key, raising=False)
+
+        from edgetutor.core.settings import Settings
+
+        s = Settings(
+            _env_file="nonexistent.env",
+            port=8080,
+            llm_temperature=0.0,
+            llm_context_size=128,
+            llm_max_tokens=1,
+            rag_top_k=1,
+            rag_chunk_size=50,
+            tts_rate=0.1,
+        )
+        assert s.port == 8080
+        assert s.llm_temperature == 0.0
+        assert s.llm_context_size == 128
+        assert s.rag_top_k == 1
+        assert s.tts_rate == 0.1
+
+    def test_gpu_layers_negative_one_allowed(self, monkeypatch):
+        """GPU layers of -1 (all layers) should be accepted."""
+        for key in ("STT_ENABLED", "TTS_ENABLED", "CAMERA_ENABLED", "LLM_MODEL_PATH"):
+            monkeypatch.delenv(key, raising=False)
+
+        from edgetutor.core.settings import Settings
+
+        s = Settings(_env_file="nonexistent.env", llm_n_gpu_layers=-1)
+        assert s.llm_n_gpu_layers == -1

--- a/edgetutor/tests/test_stt.py
+++ b/edgetutor/tests/test_stt.py
@@ -1,0 +1,124 @@
+"""Tests for edgetutor.audio.stt — Speech-to-Text engine (mock-based)."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestSTTEngineInit:
+    """Test STTEngine initialization and state."""
+
+    def test_default_state(self):
+        """STT engine should start unready with no model."""
+        from edgetutor.audio.stt import STTEngine
+
+        engine = STTEngine()
+        assert engine.is_ready is False
+        assert engine.model is None
+
+    def test_singleton_returns_instance(self):
+        """get_stt() should return an STTEngine."""
+        from edgetutor.audio.stt import STTEngine, get_stt
+
+        engine = get_stt()
+        assert isinstance(engine, STTEngine)
+
+
+class TestSTTLoad:
+    """Test model loading (mocked)."""
+
+    def test_load_when_disabled(self, monkeypatch):
+        """Should return False when STT is disabled in settings."""
+        from edgetutor.audio.stt import STTEngine
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "stt_enabled", False)
+
+        engine = STTEngine()
+        result = engine.load()
+        assert result is False
+        assert engine.is_ready is False
+
+    def test_load_missing_package(self, monkeypatch):
+        """Should return False if faster-whisper is not installed."""
+        from edgetutor.audio.stt import STTEngine
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "stt_enabled", True)
+
+        engine = STTEngine()
+
+        with patch.dict("sys.modules", {"faster_whisper": None}):
+            result = engine.load()
+
+        assert result is False
+        assert engine.is_ready is False
+
+
+class TestSTTTranscribe:
+    """Test transcription methods (mocked)."""
+
+    def test_transcribe_when_not_ready(self):
+        """Transcribing without a loaded model should return error."""
+        from edgetutor.audio.stt import STTEngine
+
+        engine = STTEngine()
+        result = engine.transcribe("/fake/audio.wav")
+        assert result["text"] == ""
+        assert "error" in result
+        assert "not loaded" in result["error"].lower()
+
+    def test_transcribe_numpy_when_not_ready(self):
+        """Numpy transcription without a loaded model should return error."""
+        from edgetutor.audio.stt import STTEngine
+
+        engine = STTEngine()
+        result = engine.transcribe_numpy([0.0, 0.1, 0.2])
+        assert result["text"] == ""
+        assert "error" in result
+
+    def test_transcribe_numpy_normalizes_audio(self, monkeypatch):
+        """Should normalize audio to float32 mono and call model."""
+        import numpy as np
+
+        from edgetutor.audio.stt import STTEngine
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "stt_language", "en")
+
+        engine = STTEngine()
+        engine._ready = True
+
+        # Mock model
+        mock_segment = MagicMock()
+        mock_segment.text = " Hello world "
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.duration = 1.5
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = (iter([mock_segment]), mock_info)
+        engine.model = mock_model
+
+        # Stereo int16 input
+        audio = np.array([[100, 200], [300, 400]], dtype=np.int16)
+        result = engine.transcribe_numpy(audio, sample_rate=16000)
+
+        assert result["text"] == "Hello world"
+        assert result["language"] == "en"
+        mock_model.transcribe.assert_called_once()
+
+    def test_transcribe_handles_exception(self):
+        """Model exception should return error dict, not raise."""
+        from edgetutor.audio.stt import STTEngine
+
+        engine = STTEngine()
+        engine._ready = True
+        engine.model = MagicMock()
+        engine.model.transcribe.side_effect = RuntimeError("decode failed")
+
+        result = engine.transcribe("/fake/audio.wav")
+        assert result["text"] == ""
+        assert "error" in result
+        assert "decode failed" in result["error"]

--- a/edgetutor/tests/test_tts.py
+++ b/edgetutor/tests/test_tts.py
@@ -1,0 +1,147 @@
+"""Tests for edgetutor.audio.tts — Text-to-Speech engine (mock-based)."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestTTSEngineInit:
+    """Test TTSEngine initialization and state."""
+
+    def test_default_state(self):
+        """TTS engine should start unready with no voice."""
+        from edgetutor.audio.tts import TTSEngine
+
+        engine = TTSEngine()
+        assert engine.is_ready is False
+        assert engine.voice is None
+        assert engine.synthesizer is None
+
+    def test_singleton_returns_instance(self):
+        """get_tts() should return a TTSEngine."""
+        from edgetutor.audio.tts import TTSEngine, get_tts
+
+        engine = get_tts()
+        assert isinstance(engine, TTSEngine)
+
+
+class TestTTSLoad:
+    """Test voice loading (mocked)."""
+
+    def test_load_when_disabled(self, monkeypatch):
+        """Should return False when TTS is disabled in settings."""
+        from edgetutor.audio.tts import TTSEngine
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "tts_enabled", False)
+
+        engine = TTSEngine()
+        result = engine.load()
+        assert result is False
+        assert engine.is_ready is False
+
+    def test_load_missing_voice_file(self, monkeypatch, tmp_path):
+        """Should return False when voice model file doesn't exist."""
+        from edgetutor.audio.tts import TTSEngine
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "tts_enabled", True)
+        monkeypatch.setattr(cfg, "tts_voice_model", str(tmp_path / "nonexistent.onnx"))
+
+        engine = TTSEngine()
+
+        with patch.object(
+            type(cfg),
+            "tts_voice_resolved",
+            new_callable=lambda: property(lambda s: tmp_path / "nonexistent.onnx"),
+        ):
+            result = engine.load()
+
+        assert result is False
+        assert engine.is_ready is False
+
+    def test_load_missing_package(self, monkeypatch, tmp_path):
+        """Should return False if piper-tts is not installed."""
+        from edgetutor.audio.tts import TTSEngine
+        from edgetutor.core.settings import get_settings
+
+        cfg = get_settings()
+        monkeypatch.setattr(cfg, "tts_enabled", True)
+
+        # Create a fake voice file so the file-exists check passes
+        voice_file = tmp_path / "test_voice.onnx"
+        voice_file.write_text("fake")
+
+        engine = TTSEngine()
+
+        with (
+            patch.object(
+                type(cfg),
+                "tts_voice_resolved",
+                new_callable=lambda: property(lambda s: voice_file),
+            ),
+            patch.dict("sys.modules", {"piper": None}),
+        ):
+            result = engine.load()
+
+        assert result is False
+
+
+class TestTTSSynthesize:
+    """Test synthesis methods (mocked)."""
+
+    def test_synthesize_when_not_ready(self):
+        """Synthesis without a loaded voice should return None."""
+        from edgetutor.audio.tts import TTSEngine
+
+        engine = TTSEngine()
+        result = engine.synthesize("Hello world")
+        assert result is None
+
+    def test_synthesize_empty_text(self):
+        """Empty text should return None."""
+        from edgetutor.audio.tts import TTSEngine
+
+        engine = TTSEngine()
+        engine._ready = True
+        engine.voice = MagicMock()
+        assert engine.synthesize("") is None
+        assert engine.synthesize("   ") is None
+
+    def test_get_audio_tuple_when_not_ready(self):
+        """get_audio_tuple without a loaded voice should return None."""
+        from edgetutor.audio.tts import TTSEngine
+
+        engine = TTSEngine()
+        result = engine.get_audio_tuple("Hello")
+        assert result is None
+
+    def test_synthesize_to_file_when_not_ready(self, tmp_path):
+        """synthesize_to_file without a loaded voice should return False."""
+        from edgetutor.audio.tts import TTSEngine
+
+        engine = TTSEngine()
+        result = engine.synthesize_to_file("Hello", tmp_path / "out.wav")
+        assert result is False
+
+    def test_synthesize_to_file_creates_directory(self, tmp_path):
+        """synthesize_to_file should create parent directories."""
+        from edgetutor.audio.tts import TTSEngine
+
+        engine = TTSEngine()
+        engine._ready = True
+        engine._sample_rate = 22050
+
+        # Create a real minimal WAV
+        mock_voice = MagicMock()
+
+        def fake_synth(text, wav_file):
+            wav_file.writeframes(b"\x00\x00" * 100)
+
+        mock_voice.synthesize = fake_synth
+        engine.voice = mock_voice
+
+        output = tmp_path / "subdir" / "output.wav"
+        result = engine.synthesize_to_file("Hello", output)
+        assert result is True
+        assert output.exists()

--- a/edgetutor/vision/ocr.py
+++ b/edgetutor/vision/ocr.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import re
 import time
 from pathlib import Path
-from typing import Optional
 
 from edgetutor.core.logging_config import get_logger
 from edgetutor.core.settings import get_settings
@@ -47,7 +46,7 @@ class OCREngine:
     def extract_text(
         self,
         image_input,
-        language: Optional[str] = None,
+        language: str | None = None,
     ) -> dict:
         """
         Extract text from an image.

--- a/edgetutor/vision/ocr.py
+++ b/edgetutor/vision/ocr.py
@@ -92,9 +92,7 @@ class OCREngine:
             t0 = time.time()
 
             # Get detailed data for confidence
-            data = pytesseract.image_to_data(
-                image, lang=lang, output_type=pytesseract.Output.DICT
-            )
+            data = pytesseract.image_to_data(image, lang=lang, output_type=pytesseract.Output.DICT)
 
             # Also get plain text (often cleaner)
             text = pytesseract.image_to_string(image, lang=lang).strip()

--- a/edgetutor/vision/ocr.py
+++ b/edgetutor/vision/ocr.py
@@ -73,8 +73,8 @@ class OCREngine:
         lang = language or cfg.ocr_language
 
         try:
-            from PIL import Image
             import pytesseract
+            from PIL import Image
 
             # Normalize input to PIL Image
             if isinstance(image_input, (str, Path)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "edgetutor-ai"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Offline AI Tutor for NVIDIA Jetson — voice, vision, and chat"
 readme = "README.md"
 license = {text = "MIT"}
@@ -66,6 +66,9 @@ Issues = "https://github.com/thatcooperguy/Nvidia_Jetson_AI_Tutor/issues"
 
 [tool.setuptools.packages.find]
 include = ["edgetutor*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "edgetutor.__version__"}
 
 [tool.ruff]
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "edgetutor-ai"
@@ -25,27 +25,33 @@ classifiers = [
 ]
 
 dependencies = [
-    "gradio>=4.0,<5.0",
     "python-dotenv>=1.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "Pillow>=10.0",
     "numpy>=1.24",
     "pytesseract>=0.3.10",
+    "pypdf>=3.0",
+]
+
+[project.optional-dependencies]
+# Heavy ML/AI deps — installed on device, not required for linting/testing
+ai = [
+    "gradio>=4.0,<5.0",
     "llama-cpp-python>=0.2.50",
     "faster-whisper>=1.0.0",
     "piper-tts>=1.2.0",
     "faiss-cpu>=1.7.4",
     "sentence-transformers>=2.2.0",
-    "pypdf>=3.0",
 ]
-
-[project.optional-dependencies]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "ruff>=0.3.0",
     "black>=24.0",
+]
+all = [
+    "edgetutor-ai[ai,dev]",
 ]
 gpu = [
     # On Jetson, install llama-cpp-python with CUDA support:

--- a/scripts/setup_jetson.sh
+++ b/scripts/setup_jetson.sh
@@ -59,7 +59,7 @@ echo "  ✅ Python venv ready ($(python3 --version))"
 # ── Step 3: Install Python dependencies ──────────────────────────────────────
 echo ""
 echo "▶ [3/7] Installing Python dependencies..."
-pip install -e "${REPO_ROOT}[dev]" -q 2>&1 | tail -5
+pip install -e "${REPO_ROOT}[ai,dev]" -q 2>&1 | tail -5
 
 echo "  ✅ Python dependencies installed."
 


### PR DESCRIPTION
## Summary
- **Streaming UI**: Wire `process_stream()` to Gradio for real-time token display during inference
- **Conversation persistence**: `ConversationStore` with JSON save/load, auto-saves after each response
- **Orchestrator-level safety**: Block unsafe input before LLM even when model isn't loaded; post-stream output safety check replaces (not appends) filtered content
- **Config validation**: `Field(ge=..., le=...)` constraints on port, temperature, context size, GPU layers, RAG params, TTS rate
- **Version de-duplication**: Single source of truth in `edgetutor/__version__`, pyproject.toml reads dynamically
- **Integration tests**: Full `process()` and `process_stream()` pipeline tests with mocked LLM/STT/OCR/RAG
- **Configurable history limit**: `CONVERSATION_HISTORY_LIMIT` env var (default 20)
- **TYPE_CHECKING imports**: Proper `NDArray`/`Image.Image` types without runtime dependency
- **Leetspeak safety**: Character-level normalization catches `w3ap0n`, `dr@g$`, etc.
- **Test coverage**: 71 ? **161 tests** across 16 test files, 12/12 modules covered
- **Docs**: CONTRIBUTING.md, PR template, README dependency extras table

## Test plan
- [x] 161 tests passing locally (`pytest`)
- [x] `ruff check` clean (E, F, I, W, UP, B, SIM rules)
- [x] `ruff format --check` clean
- [x] CI green on all pushes (7 consecutive runs)

?? Generated with [Claude Code](https://claude.com/claude-code)